### PR TITLE
Rationalize copyrights headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,10 @@
+# This is the official list of Bazel authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as:
+# Name or Organization <email address>
+# The email address is not required for organizations.
+
+Google Inc.
+Manfred Touron <m@42.am>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,17 @@
+# People who have agreed to one of the CLAs and can contribute patches.
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, Google employees are listed here
+# but not in AUTHORS, because Google holds the copyright.
+#
+# https://developers.google.com/open-source/cla/individual
+# https://developers.google.com/open-source/cla/corporate
+#
+# Names should be added to this file as:
+#     Name <email address>
+
+Kristina Chodorow <kchodorow@google.com>
+Damien Martin-Guillerez <dmarting@google.com>
+Han-Wen Nienhuys <hanwen@google.com>
+Christopher Parsons <cparsons@google.com>
+Michael Staib <mstaib@google.com>
+Manfred Touron <m@42.am>

--- a/android-ndk/BUILD
+++ b/android-ndk/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2015 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/android-ndk/BUILD.sysroot
+++ b/android-ndk/BUILD.sysroot
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2015 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/android-ndk/CROSSTOOL
+++ b/android-ndk/CROSSTOOL
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2015 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/android-prebuilts/BUILD
+++ b/android-prebuilts/BUILD
@@ -1,7 +1,7 @@
 # The whole of crosstool for all configurations.
 
 #
-# Copyright 2014 Google Inc. All Rights Reserved.
+# Copyright 2014 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/android-prebuilts/gen-crosstool.py
+++ b/android-prebuilts/gen-crosstool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2014 Google Inc. All Rights Reserved.
+# Copyright 2014 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/android-prebuilts/get-toolchains.sh
+++ b/android-prebuilts/get-toolchains.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2014 Google Inc. All Rights Reserved.
+# Copyright 2014 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/protobuf-2.5.0/BUILD
+++ b/protobuf-2.5.0/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Google Inc. All Rights Reserved.
+# Copyright 2014 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/protobuf-2.5.0/BUILD.src.google.protobuf
+++ b/protobuf-2.5.0/BUILD.src.google.protobuf
@@ -1,7 +1,7 @@
 # -*- Python -*-
 
 #
-# Copyright 2014 Google Inc. All Rights Reserved.
+# Copyright 2014 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/re2/BUILD
+++ b/re2/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2015 The Bazel Authors Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tutorial/android/src/main/java/com/google/bazel/example/android/activities/MainActivity.java
+++ b/tutorial/android/src/main/java/com/google/bazel/example/android/activities/MainActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All rights reserved.
+// Copyright 2015 The Bazel Authors Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tutorial/appengine.BUILD
+++ b/tutorial/appengine.BUILD
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 The Bazel Authors Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tutorial/backend/src/main/java/com/google/bazel/example/app/MyAppServlet.java
+++ b/tutorial/backend/src/main/java/com/google/bazel/example/app/MyAppServlet.java
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All rights reserved.
+// Copyright 2015 The Bazel Authors Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tutorial/ci/build.sh
+++ b/tutorial/ci/build.sh
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 The Bazel Authors Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tutorial/ios-app/UrlGet/AppDelegate.h
+++ b/tutorial/ios-app/UrlGet/AppDelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All rights reserved.
+// Copyright 2015 The Bazel Authors Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tutorial/ios-app/UrlGet/AppDelegate.m
+++ b/tutorial/ios-app/UrlGet/AppDelegate.m
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All rights reserved.
+// Copyright 2015 The Bazel Authors Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tutorial/ios-app/UrlGet/UrlGet-Info.plist
+++ b/tutorial/ios-app/UrlGet/UrlGet-Info.plist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2015 Google Inc. All rights reserved.
+ Copyright 2015 The Bazel Authors Inc. All rights reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/tutorial/ios-app/UrlGet/UrlGetViewController.h
+++ b/tutorial/ios-app/UrlGet/UrlGetViewController.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All rights reserved.
+// Copyright 2015 The Bazel Authors Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tutorial/ios-app/UrlGet/UrlGetViewController.m
+++ b/tutorial/ios-app/UrlGet/UrlGetViewController.m
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All rights reserved.
+// Copyright 2015 The Bazel Authors Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tutorial/ios-app/UrlGet/main.m
+++ b/tutorial/ios-app/UrlGet/main.m
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All rights reserved.
+// Copyright 2015 The Bazel Authors Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The headers were modified with
`find . -type f -exec 'sed' '-Ei' 's|Copyright 201([45]) Google|Copyright 201\1 The Bazel Authors|' '{}' ';'`
And manual edit for not Google owned copyright.

The list of authors were extracted from the git log.