### PR TITLE
Update tutorial to use rules_appengine repository

### DIFF
--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -1,59 +1,8 @@
-new_http_archive(
-    name = "com_google_appengine_java",
-    url = "http://central.maven.org/maven2/com/google/appengine/appengine-java-sdk/1.9.23/appengine-java-sdk-1.9.23.zip",
-    sha256 = "05e667036e9ef4f999b829fc08f8e5395b33a5a3c30afa9919213088db2b2e89",
-    build_file = "appengine.BUILD",
+git_repository(
+    name = "io_bazel_rules_appengine",
+    remote = "https://github.com/bazelbuild/rules_appengine.git",
+    tag = "0.0.2",
 )
 
-bind(
-    name = "appengine/java/sdk",
-    actual = "@com_google_appengine_java//:sdk",
-)
-
-bind(
-    name = "appengine/java/api",
-    actual = "@com_google_appengine_java//:api",
-)
-
-bind(
-    name = "appengine/java/jars",
-    actual = "@com_google_appengine_java//:jars",
-)
-
-maven_jar(
-    name = "org_apache_commons_lang",
-    artifact = "commons-lang:commons-lang:2.6",
-)
-
-maven_jar(
-    name = "org_apache_commons_collections",
-    artifact = "commons-collections:commons-collections:3.2.1",
-)
-
-maven_jar(
-    name = "javax_servlet_api",
-    artifact = "javax.servlet:servlet-api:2.5",
-)
-
-bind(
-    name = "javax/servlet/api",
-    actual = "@bazel_tools//tools/build_rules/appengine:javax.servlet.api",
-)
-
-maven_jar(
-    name = "json",
-    artifact = "org.json:json:20141113",
-)
-
-# To build the example Android app, uncomment this rule and set the three
-# parameters: path, api_level, build_tools_version.
-
-# android_sdk_repository(
-#     name = "androidsdk",
-#     # Set the path to the directory the Android SDK was unzipped into.
-#     path = "/path/to/android-sdk",
-#     # Set the API level of the installed SDK Platform.
-#     api_level = 22,
-#     # Set the version of the build tools (a directory inside build-tools)
-#     build_tools_version="22.0.1"
-# )
+load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_repositories")
+appengine_repositories()

--- a/tutorial/backend/BUILD
+++ b/tutorial/backend/BUILD
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_rules/appengine:appengine.bzl", "appengine_war")
+load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_war")
 
 appengine_war(
     name = "backend",
@@ -21,6 +21,6 @@ java_binary(
     srcs = glob(["src/main/java/**/*.java"]),
     main_class = "does.not.exist",
     deps = [
-        "//external:javax/servlet/api",
+        "@io_bazel_rules_appengine//appengine:javax.servlet.api",
     ],
 )


### PR DESCRIPTION
This falls out from removing the @bazel_tools appengine rules.