### PR TITLE
Make the tutorial build more compatible with ci.bazel.io

### DIFF
--- a/tutorial/BUILD
+++ b/tutorial/BUILD
@@ -1,0 +1,23 @@
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_x86_64",
+    values = {"cpu": "darwin_x86_64"},
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all",
+    srcs = [
+        "//backend",
+        "//android",
+    ] + select({
+        ":darwin": ["//ios-app"],
+        ":darwin_x86_64": ["//ios-app"],
+        "//conditions:default": [],
+    }),
+)

--- a/tutorial/ci/setup_android_repositories.sh
+++ b/tutorial/ci/setup_android_repositories.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function setup_android_repositories() {
+  if [ ! -f WORKSPACE.bak ] && [ -n "${ANDROID_SDK_PATH-}" ]; then
+    cp WORKSPACE WORKSPACE.bak
+    trap '[ -f WORKSPACE.bak ] && rm WORKSPACE && mv WORKSPACE.bak WORKSPACE' \
+      EXIT
+    # Make sure that WORKSPACE ends with a newline, otherwise we'll end up with
+    # a syntax error.
+    echo >>WORKSPACE
+    cat >>WORKSPACE <<EOF
+android_sdk_repository(
+    name = "androidsdk",
+    path = "${ANDROID_SDK_PATH}",
+    build_tools_version = "${ANDROID_SDK_BUILD_TOOLS_VERSION:-22.0.1}",
+    api_level = ${ANDROID_SDK_API_LEVEL:-21},
+)
+
+bind(
+    name = "android_sdk_for_testing",
+    actual = "@androidsdk//:files",
+)
+EOF
+    if [ -n "${ANDROID_NDK_PATH-}" ]; then
+      cat >>WORKSPACE <<EOF
+android_ndk_repository(
+    name = "androidndk",
+    path = "${ANDROID_NDK_PATH}",
+    api_level = ${ANDROID_NDK_API_LEVEL:-21},
+)
+
+bind(
+    name = "android_ndk_for_testing",
+    actual = "@androidndk//:files",
+)
+EOF
+    fi
+  fi
+}
+
+setup_android_repositories


### PR DESCRIPTION
The way the tutorial is build on ci was a bit off the way we build the other.
These two changes:
  - create a `//:all` target to build that select automatically what to build using select.
  - add a setup script for the android tooling so we can run that as a configure step.
