### PR TITLE
Update AppEngine rule to use tag 0.0.3 rather than a specific commit

### DIFF
--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -1,7 +1,7 @@
 git_repository(
     name = "io_bazel_rules_appengine",
     remote = "https://github.com/bazelbuild/rules_appengine.git",
-    commit = "8788772d4c420b8a3075d32e4dc7e442e7430e74",
+    tag = "0.0.3",
 )
 
 load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_repositories")


### PR DESCRIPTION
The online tutorial currently directs you to use tag 0.0.2, which is
obsolete and doesn't work any more. The master branch of the tutorial
was updated to use a specific commit, but the online tutorial wasn't.

This change updates the rule to use the latest tag (0.0.3). I'll also
fix up the online tutorial page, which is in a different repo.