### PR TITLE
Remove offband ios sdk detection from CI script

### DIFF
--- a/tutorial/ci/build.sh
+++ b/tutorial/ci/build.sh
@@ -22,8 +22,6 @@
 #      the android build won't be tested. The 2 other one are defaulted
 #      to, respectively, "22" and "22.0.1".
 
-IOS_SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
-
 # Go to the workspace root
 cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
 
@@ -75,7 +73,7 @@ fi
 
 # Under darwin, test the ios application
 if [ "$(uname -s | tr 'A-Z' 'a-z')" = "darwin" ]; then
-  "${BAZEL}" build //ios-app --ios_sdk_version=$IOS_SDK_VERSION
+  "${BAZEL}" build //ios-app
 fi
 
 echo "Yay!"


### PR DESCRIPTION
IOS SDK detection is now handled by the xcode_configure repository rule, and thus passing --ios_sdk_version may not match the actual system default.