### PR TITLE
Update default Android version to 24

### DIFF
--- a/tutorial/ci/setup_android_repositories.sh
+++ b/tutorial/ci/setup_android_repositories.sh
@@ -26,8 +26,6 @@ function setup_android_repositories() {
 android_sdk_repository(
     name = "androidsdk",
     path = "${ANDROID_SDK_PATH}",
-    build_tools_version = "${ANDROID_SDK_BUILD_TOOLS_VERSION:-22.0.1}",
-    api_level = ${ANDROID_SDK_API_LEVEL:-24},
 )
 
 bind(
@@ -40,7 +38,6 @@ EOF
 android_ndk_repository(
     name = "androidndk",
     path = "${ANDROID_NDK_PATH}",
-    api_level = ${ANDROID_NDK_API_LEVEL:-24},
 )
 
 bind(

--- a/tutorial/ci/setup_android_repositories.sh
+++ b/tutorial/ci/setup_android_repositories.sh
@@ -27,7 +27,7 @@ android_sdk_repository(
     name = "androidsdk",
     path = "${ANDROID_SDK_PATH}",
     build_tools_version = "${ANDROID_SDK_BUILD_TOOLS_VERSION:-22.0.1}",
-    api_level = ${ANDROID_SDK_API_LEVEL:-21},
+    api_level = ${ANDROID_SDK_API_LEVEL:-24},
 )
 
 bind(
@@ -40,7 +40,7 @@ EOF
 android_ndk_repository(
     name = "androidndk",
     path = "${ANDROID_NDK_PATH}",
-    api_level = ${ANDROID_NDK_API_LEVEL:-21},
+    api_level = ${ANDROID_NDK_API_LEVEL:-24},
 )
 
 bind(


### PR DESCRIPTION
Stopgap (but not the proper fix) for https://github.com/bazelbuild/continuous-integration/issues/74.