### PR TITLE
Add visibility attribute to ios-app to allow building //:all to work.

### DIFF
--- a/tutorial/ios-app/BUILD
+++ b/tutorial/ios-app/BUILD
@@ -3,9 +3,9 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 objc_library(
     name = "UrlGetClasses",
     srcs = [
-	"UrlGet/main.m",
         "UrlGet/AppDelegate.m",
         "UrlGet/UrlGetViewController.m",
+        "UrlGet/main.m",
     ],
     hdrs = glob(["UrlGet/*.h"]),
     xibs = ["UrlGet/UrlGetViewController.xib"],
@@ -13,8 +13,12 @@ objc_library(
 
 ios_application(
     name = "ios-app",
-    deps = [":UrlGetClasses"],
     bundle_id = "Google.UrlGet",
-    families = ["iphone", "ipad"],
+    families = [
+        "iphone",
+        "ipad",
+    ],
     infoplists = [":UrlGet/UrlGet-Info.plist"],
+    visibility = ["//visibility:public"],
+    deps = [":UrlGetClasses"],
 )


### PR DESCRIPTION
I also ran buildifier on the ios-app BUILD file to clean it up.