### PR TITLE
sync ios tutorial apple rules repository to 07-19-17

### DIFF
--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -1,7 +1,7 @@
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    commit = "4ac137080708924f6da02f8165b1c53b99d2d1c7", # 07-19-17
+    commit = "32ed0d1712923766d930c4b39ca45ada16367a2c", # 07-25-17
 )
 
 http_archive(

--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -1,7 +1,7 @@
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.0.1",
+    commit = "4ac137080708924f6da02f8165b1c53b99d2d1c7", # 07-19-17
 )
 
 http_archive(


### PR DESCRIPTION
Needed as bazel at HEAD has some changes incompatible with the "0.0.1" version of apple rules, and it's breaking our CI.