### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/rules/computed_dependencies/hash.bzl
+++ b/rules/computed_dependencies/hash.bzl
@@ -31,9 +31,9 @@ def _impl(ctx):
     processed = src
   else:
     # The temporary file is based on 'ctx.label.name' to avoid conflicts.
-    processed = ctx.new_file(ctx.label.name + "_processed")
+    processed = ctx.actions.declare_file(ctx.label.name + "_processed")
     # Run the selected binary
-    ctx.action(
+    ctx.actions.run(
         outputs = [processed],
         inputs = [ctx.file.src],
         progress_message="Apply filter '%s'" % ctx.attr.filter,
@@ -42,7 +42,7 @@ def _impl(ctx):
 
   # Compute the hash
   out = ctx.outputs.text
-  ctx.action(
+  ctx.actions.run_shell(
       outputs = [out],
       inputs = [processed],
       command = "md5sum < %s > %s" % (processed.path, out.path))

--- a/rules/custom_outputs/extension.bzl
+++ b/rules/custom_outputs/extension.bzl
@@ -7,7 +7,7 @@ each of them.
 def _impl(ctx):
   # Access the custom outputs using ctx.outputs.<attribute name>.
   for output in ctx.outputs.outs:
-    ctx.file_action(
+    ctx.actions.write(
         output=output,
         content="I am " + output.short_path + "\n"
     )

--- a/rules/default_outputs/extension.bzl
+++ b/rules/default_outputs/extension.bzl
@@ -1,7 +1,7 @@
 """This example creates a rule with a declared output."""
 
 def _impl(ctx):
-  ctx.file_action(
+  ctx.actions.write(
       # Access the default outputs using ctx.outputs.<output name>.
       output=ctx.outputs.my_output,
       content="Hello World!"

--- a/rules/executable/executable.bzl
+++ b/rules/executable/executable.bzl
@@ -6,10 +6,10 @@ can also be executed as part of the build.
 
 def _impl(ctx):
   # The implementation function must generate the file 'ctx.outputs.executable'.
-  ctx.file_action(
+  ctx.actions.write(
       output=ctx.outputs.executable,
       content="#!/bin/bash\necho Hello!",
-      executable=True
+      is_executable=True
   )
   # The executable output is added automatically to this target.
 

--- a/rules/expand_template/hello.bzl
+++ b/rules/expand_template/hello.bzl
@@ -2,10 +2,7 @@
 _TEMPLATE = "//expand_template:hello.cc"
 
 def _hello_impl(ctx):
-  # 'ctx.template_action' is the old API.
-  # We use it for compatibility with Bazel 0.5.2.
-  # Later, we'll use 'ctx.actions.expand_template' instead.
-  ctx.template_action(
+  ctx.actions.expand_template(
       template=ctx.file._template,
       output=ctx.outputs.source_file,
       substitutions={

--- a/rules/test_rule/line_length.bzl
+++ b/rules/test_rule/line_length.bzl
@@ -17,7 +17,7 @@ def _impl(ctx):
       ["exit $err"])
 
   # Write the file, it is executed by 'bazel test'.
-  ctx.file_action(
+  ctx.actions.write(
       output=ctx.outputs.executable,
       content=script)
 


### PR DESCRIPTION
Modify the examples to no longer use deprecated APIs. For example, instead of `ctx.action()`, the examples now use `ctx.actions.run()` and `ctx.actions.run_shell()`.