### PR TITLE
Return DefaultInfo from _foo_library_impl()

### DIFF
--- a/rules/depsets/foo.bzl
+++ b/rules/depsets/foo.bzl
@@ -16,7 +16,10 @@ def get_transitive_srcs(srcs, deps):
 
 def _foo_library_impl(ctx):
     trans_srcs = get_transitive_srcs(ctx.files.srcs, ctx.attr.deps)
-    return [FooFiles(transitive_sources = trans_srcs)]
+    return [
+        FooFiles(transitive_sources = trans_srcs),
+        DefaultInfo(files = trans_srcs),
+    ]
 
 foo_library = rule(
     implementation = _foo_library_impl,


### PR DESCRIPTION
If we don't do this, transitive uses of foo_library three or more
layers deep fail to compile.

See also bazelbuild/rules_sass#33