### PR TITLE
Fix ios-app build

### DIFF
--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -1,7 +1,7 @@
 http_archive(
     name = "build_bazel_rules_apple",
-    strip_prefix = "rules_apple-0.2.0",
-    urls = ["https://github.com/bazelbuild/rules_apple/archive/0.2.0.tar.gz"], # 2017-11-22
+    strip_prefix = "rules_apple-0.7.0",
+    urls = ["https://github.com/bazelbuild/rules_apple/archive/0.7.0.tar.gz"], # 2018-08-15
 )
 
 http_archive(

--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -4,6 +4,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_apple/archive/0.7.0.tar.gz"], # 2018-08-15
 )
 
+load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+
+apple_rules_dependencies()
+
 http_archive(
     name = "io_bazel_rules_appengine",
     sha256 = "d1fbc9a48332cc00b56d66751b5eb911ac9a88e820af7a2316a9b5ed4ee46d0b",


### PR DESCRIPTION
Using Bazel 0.16.1, the ios-app example does not build. This updates the `WORKSPACE` file to fix the build.