### PR TITLE
Add simple Android example from Bazel's source tree.

### DIFF
--- a/android/simple/README.md
+++ b/android/simple/README.md
@@ -1,0 +1,88 @@
+# Simple Android Example
+
+## Setup Android SDK and NDK
+
+In order to build these examples, add the following two rules to the top-level
+`WORKSPACE` file (two directories above this file):
+
+```python
+android_sdk_repository(
+    name = "androidsdk",
+    path = "<full path to your Android SDK>",
+    api_level = "<api level>",
+)
+
+android_ndk_repository(
+    name = "androidndk",
+    path = "<path to your Android NDK>",
+    api_level = "<api_level>",
+)
+```
+
+For the `android_sdk_repository` rule, the value of `api_level` corresponds to a
+directory in the SDK containing the specific version of `android.jar` to compile
+against. For example, if `path = "/Users/<username>/Library/Android/sdk"` and
+`api_level = 27`, then the directory
+`/Users/<username>/Library/Android/sdk/platforms/android-27` must exist.
+
+Similarly, for the `android_ndk_repository` rule, the value of the `api_level`
+attribute corresponds to a directory containing the NDK libraries for that API
+level. For example, if `path=/Users/<username>/Library/Android/android-ndk-r16b`
+and `api_level=27`, then you your NDK must contain the directory
+`/Users/<username>/Library/Android/android-ndk-r16b/platforms/android-27`.
+
+The example `android_binary` depends on the
+`com.android.support:appcompat-v7:27.1.0` AAR hosted on [Google Maven
+Repository](https://maven.google.com), so you will need to add the
+[`gmaven_rules`](https://github.com/bazelbuild/gmaven_rules) dependency to the
+WORKSPACE file:
+
+```python
+# Google Maven Repository
+# Get the tag from https://github.com/bazelbuild/gmaven_rules/releases
+GMAVEN_TAG = "YYYYMMDD-<SNAPSHOT>"
+
+http_archive(
+    name = "gmaven_rules",
+    strip_prefix = "gmaven_rules-%s" % GMAVEN_TAG,
+    url = "https://github.com/bazelbuild/gmaven_rules/archive/%s.tar.gz" % GMAVEN_TAG,
+)
+
+load("@gmaven_rules//:gmaven.bzl", "gmaven_rules")
+
+gmaven_rules()
+```
+
+## Build the app
+
+The following command can be used to build the example app:
+
+```
+bazel build //java/bazel:hello_world
+```
+
+## Faster iterative development with mobile-install
+
+Bazel has a nice way to speed up the edit-compile-install development cycle for
+physical Android devices and emulators: Bazel knows what code changed since the
+last build, and can use this knowledge to install only the changed code to the
+device. This currently works with L devices and changes to Java code and Android
+resources. To try this out, take an `android_binary` rule and:
+
+ * Set the `proguard_specs` attribute to `[]` (the empty list) or just omit it
+   altogether
+ * Set the `multidex` attribute to `native`
+ * Set the `dex_shards` attribute to a number between 2 and 200. This controls
+   the size of chunks the code is split into. As this number is increased,
+   compilation and installation becomes faster but app startup becomes slower. A
+   good initial guess is 10.
+ * Connect your device over USB to your workstation and enable USB debugging on
+   it
+ * Run `bazel mobile-install //java/bazel:hello_world`
+ * Edit Java code or Android resources
+ * Run `bazel mobile-install --incremental //java/bazel:hello_world`
+
+Note that if you change anything other than Java code or Android resources (C++
+code or something on the device), you must omit the `--incremental` command line
+option. Yes, we know that this is also clunky and we are working on improving
+it.

--- a/android/simple/WORKSPACE
+++ b/android/simple/WORKSPACE
@@ -1,0 +1,16 @@
+android_sdk_repository(name = "androidsdk")
+
+android_ndk_repository(name = "androidndk")
+
+# Google Maven Repository
+GMAVEN_TAG = "20180625-1"
+
+http_archive(
+    name = "gmaven_rules",
+    strip_prefix = "gmaven_rules-%s" % GMAVEN_TAG,
+    url = "https://github.com/bazelbuild/gmaven_rules/archive/%s.tar.gz" % GMAVEN_TAG,
+)
+
+load("@gmaven_rules//:gmaven.bzl", "gmaven_rules")
+
+gmaven_rules()

--- a/android/simple/java/bazel/AndroidManifest.xml
+++ b/android/simple/java/bazel/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="bazel.android"
+    android:versionCode="1"
+    android:versionName="1.0" >
+
+    <uses-sdk
+        android:minSdkVersion="21"
+        android:targetSdkVersion="21" />
+
+    <application
+        android:label="Bazel App"
+        android:theme="@style/MyTheme" >
+        <activity
+            android:name="bazel.MainActivity"
+            android:label="Bazel" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/simple/java/bazel/BUILD
+++ b/android/simple/java/bazel/BUILD
@@ -1,0 +1,39 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//examples:__pkg__"],
+)
+
+android_library(
+    name = "lib",
+    srcs = ["Lib.java"],
+)
+
+android_binary(
+    name = "hello_world",
+    srcs = glob([
+        "MainActivity.java",
+        "Jni.java",
+    ]),
+    manifest = "AndroidManifest.xml",
+    resource_files = glob(["res/**"]),
+    deps = [
+        ":jni",
+        ":lib",
+        gmaven_artifact("com.android.support:appcompat-v7:aar:27.1.1"),
+    ],
+)
+
+cc_library(
+    name = "jni",
+    srcs = ["jni.cc"],
+    deps = [":jni_dep"],
+)
+
+cc_library(
+    name = "jni_dep",
+    srcs = ["jni_dep.cc"],
+    hdrs = ["jni_dep.h"],
+)

--- a/android/simple/java/bazel/Jni.java
+++ b/android/simple/java/bazel/Jni.java
@@ -1,0 +1,8 @@
+package bazel;
+
+/**
+ * JNI stubs for the Bazel Android "Hello, World" app.
+ */
+public class Jni {
+  public static native String hello();
+}

--- a/android/simple/java/bazel/Lib.java
+++ b/android/simple/java/bazel/Lib.java
@@ -1,0 +1,10 @@
+package bazel;
+
+/**
+ * A tiny library for the Bazel Android "Hello, World" app.
+ */
+public class Lib {
+  public static String message() {
+    return "Hello Lib";
+  }
+}

--- a/android/simple/java/bazel/MainActivity.java
+++ b/android/simple/java/bazel/MainActivity.java
@@ -1,0 +1,20 @@
+package bazel;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+
+/**
+ * Main class for the Bazel Android "Hello, World" app.
+ */
+public class MainActivity extends AppCompatActivity {
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    Log.v("Bazel", "Hello, Android");
+    Log.v("Bazel", "Lib says: " + Lib.message());
+    System.loadLibrary("hello_world");
+    Log.v("Bazel", "JNI says: " + Jni.hello());
+  }
+}

--- a/android/simple/java/bazel/jni.cc
+++ b/android/simple/java/bazel/jni.cc
@@ -1,0 +1,10 @@
+#include <jni.h>
+
+#include "java/bazel/jni_dep.h"
+
+const char* hello = "Hello JNI";
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_bazel_Jni_hello(JNIEnv *env, jclass clazz) {
+  return NewStringLatin1(env, hello);
+}

--- a/android/simple/java/bazel/jni_dep.cc
+++ b/android/simple/java/bazel/jni_dep.cc
@@ -1,0 +1,17 @@
+#include "java/bazel/jni_dep.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+jstring NewStringLatin1(JNIEnv *env, const char *str) {
+  int len = strlen(str);
+  jchar *str1;
+  str1 = reinterpret_cast<jchar *>(malloc(len * sizeof(jchar)));
+
+  for (int i = 0; i < len; i++) {
+    str1[i] = (unsigned char)str[i];
+  }
+  jstring result = env->NewString(str1, len);
+  free(str1);
+  return result;
+}

--- a/android/simple/java/bazel/jni_dep.h
+++ b/android/simple/java/bazel/jni_dep.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <jni.h>
+
+jstring NewStringLatin1(JNIEnv *env, const char *str);

--- a/android/simple/java/bazel/res/values/colors.xml
+++ b/android/simple/java/bazel/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <item name="primary" type="color">#FF99CC00</item>
+</resources>

--- a/android/simple/java/bazel/res/values/styles.xml
+++ b/android/simple/java/bazel/res/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="MyTheme" parent="Theme.AppCompat">
+        <item name="colorPrimary">@color/primary</item>
+    </style>
+</resources>


### PR DESCRIPTION
- Updated the project to make use of gmaven_rules/gmaven_artifact()
- Updated README.md to reflect latest API/NDK versions, and usage of
  gmaven_rules
- Cleaned up README.md formatting with new headers
- Changed the C++ source to reflect the new project layout, because the current
  WORKSPACE location has changed.

Related: https://github.com/bazelbuild/bazel/issues/6007

After this, we can remove the Android example from the Bazel soruce tree.