### PR TITLE
Android NDK: add drop-in replacement for http_archive

### DIFF
--- a/android/ndk/WORKSPACE
+++ b/android/ndk/WORKSPACE
@@ -5,6 +5,7 @@ android_ndk_repository(name = "androidndk")
 # Google Maven Repository
 GMAVEN_TAG = "20180625-1"
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "gmaven_rules",
     strip_prefix = "gmaven_rules-%s" % GMAVEN_TAG,


### PR DESCRIPTION
Rule http_archive was recently deprecated.

**Error message:**
ERROR: error loading package '': Encountered error while reading extension file 'gmaven.bzl': no such package '@gmaven_rules//': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.`

**Bazel version:**
Bazel version:
INFO: Invocation ID: 80ba42f0-2fb4-4032-bc43-68dc0c55cce5
Build label: 0.20.0-homebrew
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Fri Nov 30 20:40:12 2018 (1543610412)
Build timestamp: 1543610412
Build timestamp as int: 1543610412