### PR TITLE
fixing header guard name typo

### DIFF
--- a/cpp-tutorial/stage3/lib/hello-time.h
+++ b/cpp-tutorial/stage3/lib/hello-time.h
@@ -1,5 +1,5 @@
-#ifndef MAIN_HELLO_TIME_H_
-#define MAIN_HELLO_TIME_H_
+#ifndef LIB_HELLO_TIME_H_
+#define LIB_HELLO_TIME_H_
 
 void print_localtime();
 

--- a/cpp-tutorial/stage3/main/hello-greet.h
+++ b/cpp-tutorial/stage3/main/hello-greet.h
@@ -1,5 +1,5 @@
-#ifndef LIB_HELLO_GREET_H_
-#define LIB_HELLO_GREET_H_
+#ifndef MAIN_HELLO_GREET_H_
+#define MAIN_HELLO_GREET_H_
 
 #include <string>
 


### PR DESCRIPTION
fixing the header guard names in the last cpp examples