### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @laurentlb @brandjon @c-parsons @spomorski


### PR DESCRIPTION
Adding GitHub repo admins and other interested parties as global CODEOWNERS.