### PR TITLE
Fix ios-app build with Bazel 0.20.0 and above

### DIFF
--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -64,27 +64,13 @@ response in a text view.
 You can build the application by running:
 
 ```
-$ bazel build //ios-app --ios_sdk_version=8.4
+$ bazel build //ios-app
 ```
 
 Bazel will generate some output files, most notably `bazel-bin/ios-app/ios-app.xcodeproj`
 
 Open this file in xcode and run the application on your target device
 (or device simulator).
-
-The ios_sdk_version flag value currently matches the supported SDK version of
-the current stable xcode build. The iOS app may not build without this set to
-the value that matches your currently installed xcode version.  You can see the
-versions you have available by running:
-
-```
-$ xcodebuild -showsdks
-...
-iOS SDKs:
-        iOS 9.2                -sdk iphoneos9.2
-```
-
-In this case, you would pass in `--ios_sdk_version=9.2`.
 
 Continuous integration
 ----------------------

--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 git_repository(
     name = "build_bazel_rules_apple",

--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.10.0",
+    tag = "0.13.0",
 )
 
 load(


### PR DESCRIPTION
Fix ios-app build with Bazel 0.20.0 and above due to the removal of
`native.http_archive rule`.