### PR TITLE
Don't build `//...` in the NDK examples.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -29,25 +29,19 @@ tasks:
     platform: ubuntu1804
     working_directory: android/ndk
     build_targets:
-    - "..."
-    test_targets:
-    - "..."
+    - "//app/src/main:app"
   android-ndk-macos:
     name: "Android NDK"
     platform: macos
     working_directory: android/ndk
     build_targets:
-    - "..."
-    test_targets:
-    - "..."
+    - "//app/src/main:app"
   android-ndk-windows:
     name: "Android NDK"
     platform: windows
     working_directory: android/ndk
     build_targets:
-    - "..."
-    test_targets:
-    - "..."
+    - "//app/src/main:app"
   cpp-stage1-linux:
     name: "C++ Stage 1"
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -36,12 +36,14 @@ tasks:
     working_directory: android/ndk
     build_targets:
     - "//app/src/main:app"
-  android-ndk-windows:
-    name: "Android NDK"
-    platform: windows
-    working_directory: android/ndk
-    build_targets:
-    - "//app/src/main:app"
+  # NDK project is not building on Windows yet.
+  # https://github.com/bazelbuild/examples/issues/94
+  # android-ndk-windows:
+  #   name: "Android NDK"
+  #   platform: windows
+  #   working_directory: android/ndk
+  #   build_targets:
+  #   - "//app/src/main:app"
   cpp-stage1-linux:
     name: "C++ Stage 1"
     platform: ubuntu1804


### PR DESCRIPTION
The C++ library require an Android split transition that only happens at the android_binary.dep edge.