### PR TITLE
Fix Java tutorial on CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -128,23 +128,17 @@ tasks:
     working_directory: java-tutorial
     build_targets:
     - "..."
-    test_targets:
-    - "..."
   java-tutorial-macos:
     name: "Java Tutorial"
     platform: macos
     working_directory: java-tutorial
     build_targets:
     - "..."
-    test_targets:
-    - "..."
   java-tutorial-windows:
     name: "Java Tutorial"
     platform: windows
     working_directory: java-tutorial
     build_targets:
-    - "..."
-    test_targets:
     - "..."
   rules-linux:
     name: "Bazel Rules"


### PR DESCRIPTION
The failures are from requesting non-existent test targets.