### PR TITLE
Point to executable

### DIFF
--- a/rules/actions_run/BUILD
+++ b/rules/actions_run/BUILD
@@ -8,10 +8,34 @@ concat(
         "body.html",
         "footer.html",
     ],
+    merge_tool = select({
+        "//conditions:default": "//actions_run:merge_on_linux",
+        "on_linux": "//actions_run:merge_on_linux",
+        "on_windows": "//actions_run:merge_on_windows.bat",
+    }),
 )
 
 # This target is used by the shell rule.
 sh_binary(
-    name = "merge",
+    name = "merge_on_linux",
     srcs = ["merge.sh"],
+)
+
+sh_binary(
+    name = "merge_on_windows.bat",
+    srcs = ["merge.bat"],
+)
+
+config_setting(
+    name = "on_linux",
+    constraint_values = [
+        "@platforms//os:linux"
+    ],
+)
+
+config_setting(
+    name = "on_windows",
+    constraint_values = [
+        "@platforms//os:windows"
+    ],
 )

--- a/rules/actions_run/execute.bzl
+++ b/rules/actions_run/execute.bzl
@@ -18,7 +18,7 @@ def _impl(ctx):
         outputs = [ctx.outputs.out],
         arguments = args,
         progress_message = "Merging into %s" % ctx.outputs.out.short_path,
-        executable = ctx.executable._merge_tool,
+        executable = ctx.executable.merge_tool,
     )
 
 concat = rule(
@@ -26,7 +26,7 @@ concat = rule(
     attrs = {
         "chunks": attr.label_list(allow_files = True),
         "out": attr.output(mandatory = True),
-        "_merge_tool": attr.label(
+        "merge_tool": attr.label(
             executable = True,
             cfg = "host",
             allow_files = True,

--- a/rules/actions_run/merge.bat
+++ b/rules/actions_run/merge.bat
@@ -1,0 +1,13 @@
+@echo OFF
+set files=
+
+set out=%1
+
+:addparam
+shift
+if "%1"=="" goto paramscomplete
+set files=%files% %1
+goto addparam
+:paramscomplete
+
+type %files:/=\% > %out:/=\%


### PR DESCRIPTION
//actions_run:merge will not hit merge.sh.
The proposed change updates the label so that it goes to //actions_run:merge.sh.