### PR TITLE
Use proper header guard

### DIFF
--- a/cpp-tutorial/stage2/main/hello-greet.cc
+++ b/cpp-tutorial/stage2/main/hello-greet.cc
@@ -1,4 +1,4 @@
-#include "hello-greet.h"
+#include "main/hello-greet.h"
 #include <string>
 
 std::string get_greet(const std::string& who) {

--- a/cpp-tutorial/stage2/main/hello-greet.h
+++ b/cpp-tutorial/stage2/main/hello-greet.h
@@ -1,5 +1,5 @@
-#ifndef LIB_HELLO_GREET_H_
-#define LIB_HELLO_GREET_H_
+#ifndef MAIN_HELLO_GREET_H_
+#define MAIN_HELLO_GREET_H_
 
 #include <string>
 

--- a/cpp-tutorial/stage2/main/hello-world.cc
+++ b/cpp-tutorial/stage2/main/hello-world.cc
@@ -1,4 +1,4 @@
-#include "hello-greet.h"
+#include "main/hello-greet.h"
 #include <ctime>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Header guard should be PATH_FILE_NAME_H_ as per Google style guide.

Test: run blaze build/run for all targets from stage 1, 2 and 3.
      No new warnings or issues observed.