### PR TITLE
Migrate maven_jar usage to rules_jvm_external

### DIFF
--- a/android/firebase-cloud-messaging/WORKSPACE
+++ b/android/firebase-cloud-messaging/WORKSPACE
@@ -15,9 +15,6 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
-load("@rules_jvm_external//migration:maven_jar_migrator_deps.bzl", "maven_jar_migrator_repositories")
-maven_jar_migrator_repositories()
-
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
@@ -45,13 +42,13 @@ compat_repositories()
 TOOLS_ANDROID_COMMIT = "0e864ba5a86958513658250de587416d8e17c481"
 
 http_archive(
-  name = "tools_android",
-  strip_prefix = "tools_android-" + TOOLS_ANDROID_COMMIT,
-  url = "https://github.com/bazelbuild/tools_android/archive/%s.tar.gz" % TOOLS_ANDROID_COMMIT,
-  sha256 = "57c50d6331ba578fc8adfcede20ef12b437cb4cc2edf60c852e4b834eefee5fc",
-  repo_mapping = {
-      "@com_google_code_gson_2_8_2": "@com_google_code_gson_gson",
-  },
+    name = "tools_android",
+    strip_prefix = "tools_android-" + TOOLS_ANDROID_COMMIT,
+    url = "https://github.com/bazelbuild/tools_android/archive/%s.tar.gz" % TOOLS_ANDROID_COMMIT,
+    sha256 = "57c50d6331ba578fc8adfcede20ef12b437cb4cc2edf60c852e4b834eefee5fc",
+    repo_mapping = {
+        "@com_google_code_gson_2_8_2": "@com_google_code_gson_gson",
+    },
 )
 
 load("@tools_android//tools/googleservices:defs.bzl", "google_services_workspace_dependencies")
@@ -67,8 +64,8 @@ http_archive(
 )
 
 http_archive(
-        name = "rules_cc",
-        url = "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.zip",
-        sha256 = "8c7e8bf24a2bf515713445199a677ee2336e1c487fa1da41037c6026de04bbc3",
-        strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
+    name = "rules_cc",
+    url = "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.zip",
+    sha256 = "8c7e8bf24a2bf515713445199a677ee2336e1c487fa1da41037c6026de04bbc3",
+    strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
 )

--- a/android/firebase-cloud-messaging/WORKSPACE
+++ b/android/firebase-cloud-messaging/WORKSPACE
@@ -24,7 +24,6 @@ maven_install(
         "com.android.support.constraint:constraint-layout:1.0.2",
         "com.google.code.gson:gson:2.8.2",
     ],
-    fetch_sources = True,
     repositories = [
         "https://jcenter.bintray.com",
         "https://maven.google.com",

--- a/android/firebase-cloud-messaging/WORKSPACE
+++ b/android/firebase-cloud-messaging/WORKSPACE
@@ -9,12 +9,22 @@ RULES_JVM_EXTERNAL_TAG = "2.8"
 
 RULES_JVM_EXTERNAL_SHA = "79c9850690d7614ecdb72d68394f994fef7534b292c4867ce5e7dec0aa7bdfad"
 
-http_archive(
+# http_archive(
+#     name = "rules_jvm_external",
+#     strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+#     sha256 = RULES_JVM_EXTERNAL_SHA,
+#     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+# )
+
+local_repository(
     name = "rules_jvm_external",
     sha256 = RULES_JVM_EXTERNAL_SHA,
     strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
+
+load("@rules_jvm_external//migration:maven_jar_migrator_deps.bzl", "maven_jar_migrator_repositories")
+maven_jar_migrator_repositories()
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
@@ -23,21 +33,33 @@ maven_install(
         "com.google.firebase:firebase-messaging:17.0.0",
         "com.android.support:appcompat-v7:26.1.0",
         "com.android.support.constraint:constraint-layout:1.0.2",
+        "com.google.code.gson:gson:2.8.2",
     ],
     fetch_sources = True,
     repositories = [
-        "https://jcenter.bintray.com/",
+        "https://jcenter.bintray.com",
         "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
     ],
+    fetch_sources = True,
+    version_conflict_policy = "pinned",
+    # See https://github.com/bazelbuild/rules_jvm_external/#repository-aliases
+    # This can be removed if none of your external dependencies uses `maven_jar`.
+    generate_compat_repositories = True,
 )
+load("@maven//:compat.bzl", "compat_repositories")
+compat_repositories()
 
 TOOLS_ANDROID_COMMIT = "0e864ba5a86958513658250de587416d8e17c481"
 
 http_archive(
-    name = "tools_android",
-    sha256 = "57c50d6331ba578fc8adfcede20ef12b437cb4cc2edf60c852e4b834eefee5fc",
-    strip_prefix = "tools_android-" + TOOLS_ANDROID_COMMIT,
-    url = "https://github.com/bazelbuild/tools_android/archive/%s.tar.gz" % TOOLS_ANDROID_COMMIT,
+  name = "tools_android",
+  strip_prefix = "tools_android-" + TOOLS_ANDROID_COMMIT,
+  url = "https://github.com/bazelbuild/tools_android/archive/%s.tar.gz" % TOOLS_ANDROID_COMMIT,
+  sha256 = "57c50d6331ba578fc8adfcede20ef12b437cb4cc2edf60c852e4b834eefee5fc",
+  repo_mapping = {
+      "@com_google_code_gson_2_8_2": "@com_google_code_gson_gson",
+  },
 )
 
 load("@tools_android//tools/googleservices:defs.bzl", "google_services_workspace_dependencies")

--- a/android/firebase-cloud-messaging/WORKSPACE
+++ b/android/firebase-cloud-messaging/WORKSPACE
@@ -5,21 +5,13 @@ android_sdk_repository(
     name = "androidsdk",
 )
 
-RULES_JVM_EXTERNAL_TAG = "2.8"
+RULES_JVM_EXTERNAL_TAG = "2.9"
+RULES_JVM_EXTERNAL_SHA = "e5b97a31a3e8feed91636f42e19b11c49487b85e5de2f387c999ea14d77c7f45"
 
-RULES_JVM_EXTERNAL_SHA = "79c9850690d7614ecdb72d68394f994fef7534b292c4867ce5e7dec0aa7bdfad"
-
-# http_archive(
-#     name = "rules_jvm_external",
-#     strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
-#     sha256 = RULES_JVM_EXTERNAL_SHA,
-#     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
-# )
-
-local_repository(
+http_archive(
     name = "rules_jvm_external",
-    sha256 = RULES_JVM_EXTERNAL_SHA,
     strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    sha256 = RULES_JVM_EXTERNAL_SHA,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 


### PR DESCRIPTION
maven_jar is going away. See https://github.com/bazelbuild/bazel/issues/6799