### PR TITLE
Update io_bazel_rules_appengine to fix https issue

### DIFF
--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -1,4 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -29,12 +28,14 @@ load(
 
 apple_support_dependencies()
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_appengine",
     # TODO: update to a release version that contains 339f6aba67fcedb7268cf54d1163cf7704a277ca.
     # This commit fixes the Maven artifact URLs to use "https" instead of "http".
-    commit = "339f6aba67fcedb7268cf54d1163cf7704a277ca",
-    remote = "https://github.com/bazelbuild/rules_appengine.git",
+    # We don't specify sha256, because the sha256 of GitHub-served non-release archives isn't
+    # stable.
+    urls = ["https://github.com/bazelbuild/rules_appengine/archive/339f6aba67fcedb7268cf54d1163cf7704a277ca.tar.gz"],
+    strip_prefix = "rules_appengine-339f6aba67fcedb7268cf54d1163cf7704a277ca",
 )
 
 load(

--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -1,3 +1,4 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -28,11 +29,12 @@ load(
 
 apple_support_dependencies()
 
-http_archive(
+git_repository(
     name = "io_bazel_rules_appengine",
-    sha256 = "a7683a79e2001fef2aef7f2ade5bdc1c99af30cea9445cbbf67ddf8959b8a879",
-    strip_prefix = "rules_appengine-69621ad36dcb8b8e07379eda5e7d22a83364b205",
-    url = "https://github.com/bazelbuild/rules_appengine/archive/69621ad36dcb8b8e07379eda5e7d22a83364b205.tar.gz",
+    # TODO: update to a release version that contains 339f6aba67fcedb7268cf54d1163cf7704a277ca.
+    # This commit fixes the Maven artifact URLs to use "https" instead of "http".
+    commit = "339f6aba67fcedb7268cf54d1163cf7704a277ca",
+    remote = "https://github.com/bazelbuild/rules_appengine.git",
 )
 
 load(


### PR DESCRIPTION
Update `@io_bazel_rules_appengine` to use https
for Mavel URLs.

See https://github.com/bazelbuild/rules_appengine/commit/339f6aba67fcedb7268cf54d1163cf7704a277ca

Fixes https://github.com/bazelbuild/examples/issues/144