### PR TITLE
Run buildifier --lint=fix -r .

### DIFF
--- a/android/firebase-cloud-messaging/WORKSPACE
+++ b/android/firebase-cloud-messaging/WORKSPACE
@@ -8,12 +8,13 @@ android_sdk_repository(
 )
 
 RULES_JVM_EXTERNAL_TAG = "2.9"
+
 RULES_JVM_EXTERNAL_SHA = "e5b97a31a3e8feed91636f42e19b11c49487b85e5de2f387c999ea14d77c7f45"
 
 http_archive(
     name = "rules_jvm_external",
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
@@ -26,43 +27,44 @@ maven_install(
         "com.android.support.constraint:constraint-layout:1.0.2",
         "com.google.code.gson:gson:2.8.2",
     ],
+    fetch_sources = True,
+    # See https://github.com/bazelbuild/rules_jvm_external/#repository-aliases
+    # This can be removed if none of your external dependencies uses `maven_jar`.
+    generate_compat_repositories = True,
     repositories = [
         "https://jcenter.bintray.com",
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
-    fetch_sources = True,
     version_conflict_policy = "pinned",
-    # See https://github.com/bazelbuild/rules_jvm_external/#repository-aliases
-    # This can be removed if none of your external dependencies uses `maven_jar`.
-    generate_compat_repositories = True,
 )
+
 load("@maven//:compat.bzl", "compat_repositories")
+
 compat_repositories()
 
 TOOLS_ANDROID_COMMIT = "0e864ba5a86958513658250de587416d8e17c481"
 
 http_archive(
     name = "tools_android",
-    strip_prefix = "tools_android-" + TOOLS_ANDROID_COMMIT,
-    url = "https://github.com/bazelbuild/tools_android/archive/%s.tar.gz" % TOOLS_ANDROID_COMMIT,
-    sha256 = "57c50d6331ba578fc8adfcede20ef12b437cb4cc2edf60c852e4b834eefee5fc",
     repo_mapping = {
         "@com_google_code_gson_2_8_2": "@com_google_code_gson_gson",
     },
+    sha256 = "57c50d6331ba578fc8adfcede20ef12b437cb4cc2edf60c852e4b834eefee5fc",
+    strip_prefix = "tools_android-" + TOOLS_ANDROID_COMMIT,
+    url = "https://github.com/bazelbuild/tools_android/archive/%s.tar.gz" % TOOLS_ANDROID_COMMIT,
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_android",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
     sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
     strip_prefix = "rules_android-0.1.1",
+    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
 )
 
 http_archive(
     name = "rules_cc",
-    url = "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.zip",
     sha256 = "8c7e8bf24a2bf515713445199a677ee2336e1c487fa1da41037c6026de04bbc3",
     strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
+    url = "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.zip",
 )

--- a/rules/aspect/file_collector.bzl
+++ b/rules/aspect/file_collector.bzl
@@ -42,7 +42,7 @@ def _file_collector_rule_impl(ctx):
     for dep in ctx.attr.deps:
         files = [f.short_path for f in dep[FileCollector].files.to_list()]
         content.append("files from {}: {}".format(dep.label, files))
-    content += [""]  # trailing newline
+    content.append("")  # trailing newline
 
     ctx.actions.write(
         output = ctx.outputs.out,

--- a/rules/runfiles/BUILD
+++ b/rules/runfiles/BUILD
@@ -1,6 +1,6 @@
 load(":complex_tool.bzl", "complex_tool", "sub_tool")
 load(":execute.bzl", "execute")
-load(":library.bzl", "runfiles_library", "runfiles_binary")
+load(":library.bzl", "runfiles_binary", "runfiles_library")
 load(":tool.bzl", "tool", "tool_user")
 
 # Tests in this package do not currently work on Windows (as they create
@@ -27,6 +27,7 @@ runfiles_library(
     command = "cat $(location :data.txt)",
     data = [":data.txt"],
 )
+
 runfiles_binary(
     name = "bin",
     lib = ":lib",
@@ -39,6 +40,7 @@ runfiles_binary(
 tool(
     name = "tool",
 )
+
 tool_user(
     name = "tool_user",
     tool = ":tool",
@@ -52,12 +54,12 @@ tool_user(
 sub_tool(
     name = "subtool",
 )
+
 complex_tool(
     name = "complex_tool",
 )
+
 tool_user(
     name = "complex_tool_user",
     tool = ":complex_tool",
 )
-
-

--- a/rules/runfiles/complex_tool.bzl
+++ b/rules/runfiles/complex_tool.bzl
@@ -37,12 +37,14 @@ sub_tool = rule(
         "command": attr.string(),
         "_data": attr.label(
             allow_files = True,
-            default = "//runfiles:data.txt"),
+            default = "//runfiles:data.txt",
+        ),
     },
 )
 
 def _complex_tool_impl(ctx):
     my_runfiles = ctx.runfiles(files = [ctx.files._data[0]])
+
     # Use runfiles.merge to merge the runfiles of both tools. All runfiles will
     # be rooted under the runfiles directory owned by this rule, however.
     my_runfiles = my_runfiles.merge(ctx.attr._subtool[DefaultInfo].default_runfiles)
@@ -61,9 +63,11 @@ def _complex_tool_impl(ctx):
     # This tool forwards its runfiles directory via the RUNFILES_DIR to the
     # subtool, otherwise the subtool would be looking to $0.runfiles, which does
     # not exist.
-    command = ("#!/bin/bash\nexport RUNFILES_DIR=\"$0.runfiles\" && "
-             + "${RUNFILES_DIR}/%s $1 && cat ${RUNFILES_DIR}/examples/%s >> $1") % (
-                   runfiles_relative_tool_path, ctx.files._data[0].short_path)
+    command = ("#!/bin/bash\nexport RUNFILES_DIR=\"$0.runfiles\" && " +
+               "${RUNFILES_DIR}/%s $1 && cat ${RUNFILES_DIR}/examples/%s >> $1") % (
+        runfiles_relative_tool_path,
+        ctx.files._data[0].short_path,
+    )
 
     ctx.actions.write(
         output = ctx.outputs.executable,
@@ -82,9 +86,11 @@ complex_tool = rule(
         "command": attr.string(),
         "_subtool": attr.label(
             allow_files = True,
-            default = "//runfiles:subtool"),
+            default = "//runfiles:subtool",
+        ),
         "_data": attr.label(
             allow_files = True,
-            default = "//runfiles:complex_tool_data.txt"),
+            default = "//runfiles:complex_tool_data.txt",
+        ),
     },
 )

--- a/rules/runfiles/library.bzl
+++ b/rules/runfiles/library.bzl
@@ -45,10 +45,11 @@ def _binary_impl(ctx):
 
     my_runfiles = ctx.runfiles(
         files = [ctx.attr.lib[RuntimeRequiredFiles].file],
-        transitive_files = ctx.attr.lib[RuntimeRequiredFiles].data_files)
+        transitive_files = ctx.attr.lib[RuntimeRequiredFiles].data_files,
+    )
 
     return [DefaultInfo(
-        runfiles = my_runfiles
+        runfiles = my_runfiles,
     )]
 
 runfiles_binary = rule(

--- a/rules/runfiles/tool.bzl
+++ b/rules/runfiles/tool.bzl
@@ -13,7 +13,7 @@ def _tool_impl(ctx):
     # to be relative to the directory in which the executable file is run.
     runfiles_path = "$0.runfiles/"
 
-    # Each runfile under the runfiles path resides under a directory with 
+    # Each runfile under the runfiles path resides under a directory with
     # with the same name as its workspace.
     data_file_root = runfiles_path + ctx.workspace_name + "/"
 
@@ -22,8 +22,10 @@ def _tool_impl(ctx):
     # Alternatively, one can use the root_symlinks parameter of `runfiles`
     # to create a symlink rooted directly under the {rulename}.runfiles
     # directory.
-    my_runfiles = ctx.runfiles(files = [ctx.files._data[0]],
-        root_symlinks = {"data_dep" : ctx.files._data[0]})
+    my_runfiles = ctx.runfiles(
+        files = [ctx.files._data[0]],
+        root_symlinks = {"data_dep": ctx.files._data[0]},
+    )
 
     # Even root symlinks are under the runfiles path.
     data_dep_path = runfiles_path + "data_dep"
@@ -58,7 +60,8 @@ tool = rule(
     attrs = {
         "_data": attr.label(
             allow_files = True,
-            default = "//runfiles:data.txt"),
+            default = "//runfiles:data.txt",
+        ),
     },
 )
 
@@ -74,7 +77,7 @@ def _tool_user_impl(ctx):
     ctx.actions.run(
         outputs = [my_out],
         executable = tool,
-        arguments = [my_out.path]
+        arguments = [my_out.path],
     )
 
     return [DefaultInfo(files = depset([my_out]))]
@@ -84,5 +87,4 @@ tool_user = rule(
     attrs = {
         "tool": attr.label(mandatory = True, executable = True, cfg = "host"),
     },
-
 )

--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -30,12 +30,12 @@ apple_support_dependencies()
 
 http_archive(
     name = "io_bazel_rules_appengine",
+    strip_prefix = "rules_appengine-339f6aba67fcedb7268cf54d1163cf7704a277ca",
     # TODO: update to a release version that contains 339f6aba67fcedb7268cf54d1163cf7704a277ca.
     # This commit fixes the Maven artifact URLs to use "https" instead of "http".
     # We don't specify sha256, because the sha256 of GitHub-served non-release archives isn't
     # stable.
     urls = ["https://github.com/bazelbuild/rules_appengine/archive/339f6aba67fcedb7268cf54d1163cf7704a277ca.tar.gz"],
-    strip_prefix = "rules_appengine-339f6aba67fcedb7268cf54d1163cf7704a277ca",
 )
 
 load(


### PR DESCRIPTION
Run `buildifier --lint=fix -r .` manually.

Could buildifier be made part of CI of this repo?
If so we can follow this https://github.com/bazelbuild/buildtools/tree/master/buildifier#setup-and-usage-via-bazel 

Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>