### PR TITLE
Fix typo in "predeclared_outputs" example

### DIFF
--- a/rules/predeclared_outputs/hash.bzl
+++ b/rules/predeclared_outputs/hash.bzl
@@ -24,7 +24,7 @@ def _word_hashes_impl(ctx):
     for hashfile in ctx.outputs.hashes:
         basename = hashfile.basename
         if not basename.endswith(".md5"):
-            fail("Hash file '%s' must end in '.md5'".format(basename))
+            fail("Hash file '{}' must end in '.md5'".format(basename))
         word = basename[:-len(".md5")]
 
         ctx.actions.run_shell(


### PR DESCRIPTION
The error message in this code mixes `%` with format string substitution.
This leads to a mis-rendered error message that includes `%s` in the output.