### PR TITLE
Remove unnecessary header in cpp example (stage 2)

### DIFF
--- a/cpp-tutorial/stage2/main/hello-greet.cc
+++ b/cpp-tutorial/stage2/main/hello-greet.cc
@@ -1,5 +1,4 @@
 #include "hello-greet.h"
-#include <string>
 
 std::string get_greet(const std::string& who) {
   return "Hello " + who;

--- a/cpp-tutorial/stage2/main/hello-world.cc
+++ b/cpp-tutorial/stage2/main/hello-world.cc
@@ -1,7 +1,6 @@
 #include "hello-greet.h"
 #include <ctime>
 #include <iostream>
-#include <string>
 
 void print_localtime() {
   std::time_t result = std::time(nullptr);

--- a/cpp-tutorial/stage3/main/hello-greet.cc
+++ b/cpp-tutorial/stage3/main/hello-greet.cc
@@ -1,5 +1,4 @@
 #include "main/hello-greet.h"
-#include <string>
 
 std::string get_greet(const std::string& who) {
   return "Hello " + who;

--- a/cpp-tutorial/stage3/main/hello-world.cc
+++ b/cpp-tutorial/stage3/main/hello-world.cc
@@ -1,7 +1,6 @@
 #include "lib/hello-time.h"
 #include "main/hello-greet.h"
 #include <iostream>
-#include <string>
 
 int main(int argc, char** argv) {
   std::string who = "world";


### PR DESCRIPTION
- This PR removes the header file 
```c
#include<string.h> 
```
from a few files.
- These files imported 
```c
#include "main/hello-greet.h"
```
in which the string header is already present. 
- Hence, importing just hello-greet.h will suffice.