### PR TITLE
Update docstring in actions_run example.

### DIFF
--- a/rules/actions_run/execute.bzl
+++ b/rules/actions_run/execute.bzl
@@ -4,8 +4,7 @@ The example below executes the binary target "//actions_run:merge" with
 some arguments. The binary will be automatically built by Bazel.
 
 The rule must declare its dependencies. To do that, we pass the target to
-the attribute "_merge_tool". Since it starts with an underscore, it is private
-and users cannot redefine it.
+the attribute "merge_tool".
 """
 
 def _impl(ctx):


### PR DESCRIPTION
Update the docstring to refer to `merge_tool` attribute, not `_merge_tool` to match the implementation; remove the note about private attributes.