### PR TITLE
Update examples to use an exec transition instead of host.

### DIFF
--- a/rules/actions_run/execute.bzl
+++ b/rules/actions_run/execute.bzl
@@ -28,7 +28,7 @@ concat = rule(
         "out": attr.output(mandatory = True),
         "merge_tool": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             default = Label("//actions_run:merge"),
         ),

--- a/rules/computed_dependencies/hash.bzl
+++ b/rules/computed_dependencies/hash.bzl
@@ -55,7 +55,7 @@ md5_sum = rule(
     attrs = {
         "filter": attr.string(values = _filters.keys(), default = "none"),
         "src": attr.label(mandatory = True, allow_single_file = True),
-        "_filter_bin": attr.label(default = _get_filter, executable = True, cfg = "host"),
+        "_filter_bin": attr.label(default = _get_filter, executable = True, cfg = "exec"),
     },
     outputs = {"text": "%{name}.txt"},
 )

--- a/rules/depsets/foo.bzl
+++ b/rules/depsets/foo.bzl
@@ -51,7 +51,7 @@ foo_binary = rule(
             default = Label("//depsets:foocc"),
             allow_files = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     outputs = {"out": "%{name}.out"},

--- a/rules/runfiles/tool.bzl
+++ b/rules/runfiles/tool.bzl
@@ -85,6 +85,6 @@ def _tool_user_impl(ctx):
 tool_user = rule(
     implementation = _tool_user_impl,
     attrs = {
-        "tool": attr.label(mandatory = True, executable = True, cfg = "host"),
+        "tool": attr.label(mandatory = True, executable = True, cfg = "exec"),
     },
 )


### PR DESCRIPTION
Part of improving configurability documentation,
https://github.com/bazelbuild/bazel/issues/11967.