### PR TITLE
Update rules_apple dependency to HEAD

### DIFF
--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "bdc8e66e70b8a75da23b79f1f8c6207356df07d041d96d2189add7ee0780cf4e",
-    strip_prefix = "rules_apple-b869b0d3868d78a1d4ffd866ccb304fb68aa12c3",
-    url = "https://github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz",
+    sha256 = "dab8e83b807b0af6b01b115b4fd48278924e3c01ca592ab0ef5ab541789bc450",
+    strip_prefix = "rules_apple-21c0ca93b0cd44e7eb500a1c02729a08b496b6c2",
+    url = "https://github.com/bazelbuild/rules_apple/archive/21c0ca93b0cd44e7eb500a1c02729a08b496b6c2.tar.gz",
 )
 
 load(


### PR DESCRIPTION
rules_apple was broken by changes to Bazel at HEAD,
and updating rules_apple incorporates the fix.