### PR TITLE
Bump version of rules_appengine.

### DIFF
--- a/tutorial/WORKSPACE
+++ b/tutorial/WORKSPACE
@@ -30,12 +30,12 @@ apple_support_dependencies()
 
 http_archive(
     name = "io_bazel_rules_appengine",
-    strip_prefix = "rules_appengine-339f6aba67fcedb7268cf54d1163cf7704a277ca",
+    strip_prefix = "rules_appengine-387760e4fe93821aa98c99692810da0335aadc93",
     # TODO: update to a release version that contains 339f6aba67fcedb7268cf54d1163cf7704a277ca.
     # This commit fixes the Maven artifact URLs to use "https" instead of "http".
     # We don't specify sha256, because the sha256 of GitHub-served non-release archives isn't
     # stable.
-    urls = ["https://github.com/bazelbuild/rules_appengine/archive/339f6aba67fcedb7268cf54d1163cf7704a277ca.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_appengine/archive/387760e4fe93821aa98c99692810da0335aadc93.tar.gz"],
 )
 
 load(


### PR DESCRIPTION
Old version is failing with bazel@HEAD, because of java_toolchain attribute javac and extclasspath.