### PR TITLE
Update stale "merge_tool" documentation.

### DIFF
--- a/rules/actions_run/execute.bzl
+++ b/rules/actions_run/execute.bzl
@@ -3,9 +3,7 @@
 The example below executes the binary target "//actions_run:merge" with
 some arguments. The binary will be automatically built by Bazel.
 
-The rule must declare its dependencies. To do that, we pass the target to
-the attribute "_merge_tool". Since it starts with an underscore, it is private
-and users cannot redefine it.
+The rule must declare its dependencies.
 """
 
 def _impl(ctx):


### PR DESCRIPTION
The `merge_tool` attr was updated in commit b901a7c7dcb46377b8e72f73e6c9d1a81c009424 and is no longer private. This change updates the doc comment reference.