### PR TITLE
Remove tripple slash on Windows

### DIFF
--- a/cpp-tutorial/stage1/README.md
+++ b/cpp-tutorial/stage1/README.md
@@ -12,13 +12,9 @@ cc_binary(
 )
 ```
 
-To build this example you use (notice that 3 slashes are required in windows)
+To build this example you use
 ```
 bazel build //main:hello-world
-
-# In Windows, note the three slashes
-
-bazel build ///main:hello-world
 ```
 
 If the build is successful, Bazel prints the following output:


### PR DESCRIPTION
AFAIK there is no longer a need to use tripple slash in Windows, indeed you can have problems if you do:
https://github.com/bazelbuild/examples/issues/198
In case that I am wrong then we should change it to explain in which situation tripple slash might be needed.