### PR TITLE
Remove build_tools_version

### DIFF
--- a/android/firebase-cloud-messaging/WORKSPACE
+++ b/android/firebase-cloud-messaging/WORKSPACE
@@ -1,11 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Requires ANDROID_HOME set to the path of your Android SDK.
-android_sdk_repository(
-    name = "androidsdk",
-    api_level = 28,
-    build_tools_version = "28.0.2",
-)
+android_sdk_repository(name = "androidsdk")
 
 RULES_JVM_EXTERNAL_TAG = "2.9"
 


### PR DESCRIPTION
Remove `build_tools_version` and `api_level` to let `android_sdk_repository` automatically select the latest installed version.

One of the fixes for https://github.com/bazelbuild/bazel/issues/13409#issuecomment-845265150