### PR TITLE
Migrate away from using the 'outputs' parameter

### DIFF
--- a/rules/actions_write/file.bzl
+++ b/rules/actions_write/file.bzl
@@ -5,12 +5,14 @@ large files with a lot of static content, consider using
 `ctx.actions.expand_template` instead.
 """
 
+def file(**kwargs):
+    _file(out = "{name}.txt".format(**kwargs), **kwargs)
+
 def _impl(ctx):
     output = ctx.outputs.out
     ctx.actions.write(output = output, content = ctx.attr.content)
 
-file = rule(
+_file = rule(
     implementation = _impl,
-    attrs = {"content": attr.string()},
-    outputs = {"out": "%{name}.txt"},
+    attrs = {"content": attr.string(), "out": attr.output()},
 )

--- a/rules/aspect/file_collector.bzl
+++ b/rules/aspect/file_collector.bzl
@@ -49,11 +49,14 @@ def _file_collector_rule_impl(ctx):
         content = "\n".join(content),
     )
 
-file_collector = rule(
+_file_collector = rule(
     implementation = _file_collector_rule_impl,
     attrs = {
         "deps": attr.label_list(aspects = [file_collector_aspect]),
         "extension": attr.string(default = "*"),
+        "out": attr.output(),
     },
-    outputs = {"out": "%{name}.files"},
 )
+
+def file_collector(**kwargs):
+    _file_collector(out = "{name}.files".format(**kwargs), **kwargs)

--- a/rules/computed_dependencies/hash.bzl
+++ b/rules/computed_dependencies/hash.bzl
@@ -50,12 +50,15 @@ def _impl(ctx):
         command = "md5sum < %s > %s" % (processed.path, out.path),
     )
 
-md5_sum = rule(
+_md5_sum = rule(
     implementation = _impl,
     attrs = {
         "filter": attr.string(values = _filters.keys(), default = "none"),
         "src": attr.label(mandatory = True, allow_single_file = True),
         "_filter_bin": attr.label(default = _get_filter, executable = True, cfg = "exec"),
+        "text": attr.output(),
     },
-    outputs = {"text": "%{name}.txt"},
 )
+
+def md5_sum(**kwargs):
+    _md5_sum(text = "{name}.text".format(**kwargs), **kwargs)

--- a/rules/depsets/foo.bzl
+++ b/rules/depsets/foo.bzl
@@ -42,7 +42,7 @@ def _foo_binary_impl(ctx):
         outputs = [out],
     )
 
-foo_binary = rule(
+_foo_binary = rule(
     implementation = _foo_binary_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
@@ -53,6 +53,9 @@ foo_binary = rule(
             executable = True,
             cfg = "exec",
         ),
+        "out": attr.output(),
     },
-    outputs = {"out": "%{name}.out"},
 )
+
+def foo_binary(**kwargs):
+    _foo_binary(out = "{name}.out".format(**kwargs), **kwargs)

--- a/rules/expand_template/hello.bzl
+++ b/rules/expand_template/hello.bzl
@@ -7,6 +7,12 @@ content during the analysis phase.
 # Label of the template file to use.
 _TEMPLATE = "//expand_template:hello.cc"
 
+def hello(**kwargs):
+    _hello(
+        source_file = "{name}.cc".format(**kwargs),
+        **kwargs
+    )
+
 def _hello_impl(ctx):
     ctx.actions.expand_template(
         template = ctx.file._template,
@@ -16,7 +22,7 @@ def _hello_impl(ctx):
         },
     )
 
-hello = rule(
+_hello = rule(
     implementation = _hello_impl,
     attrs = {
         "firstname": attr.string(mandatory = True),
@@ -24,6 +30,6 @@ hello = rule(
             default = Label(_TEMPLATE),
             allow_single_file = True,
         ),
+        "source_file": attr.output(mandatory = True),
     },
-    outputs = {"source_file": "%{name}.cc"},
 )

--- a/rules/implicit_output/hash.bzl
+++ b/rules/implicit_output/hash.bzl
@@ -24,14 +24,21 @@ def _impl(ctx):
     # source of another target), only the sha256 is computed.
     return DefaultInfo(files = depset([ctx.outputs.sha256]))
 
-hashes = rule(
+_hashes = rule(
     implementation = _impl,
     attrs = {
         "src": attr.label(mandatory = True, allow_single_file = True),
-    },
-    outputs = {
-        "md5": "%{name}.md5",
-        "sha1": "%{name}.sha1",
-        "sha256": "%{name}.sha256",
+        "md5": attr.output(),
+        "sha1": attr.output(),
+        "sha256": attr.output(),
     },
 )
+
+def hashes(**kwargs):
+    name = kwargs["name"]
+    _hashes(
+        md5 = "%s.md5" % name,
+        sha1 = "%s.sha1" % name,
+        sha256 = "%s.sha256" % name,
+        **kwargs
+    )

--- a/rules/mandatory_provider/sum.bzl
+++ b/rules/mandatory_provider/sum.bzl
@@ -17,12 +17,15 @@ def _impl(ctx):
     # Return the provider with result, visible to other rules.
     return [NumberInfo(number = result)]
 
-sum = rule(
+_sum = rule(
     implementation = _impl,
     attrs = {
         "number": attr.int(default = 1),
         # All deps must provide all listed providers.
         "deps": attr.label_list(providers = [NumberInfo]),
+        "out": attr.output(),
     },
-    outputs = {"out": "%{name}.sum"},
 )
+
+def sum(**kwargs):
+    _sum(out = "{name}.sum".format(**kwargs), **kwargs)

--- a/rules/optional_provider/sum.bzl
+++ b/rules/optional_provider/sum.bzl
@@ -18,11 +18,14 @@ def _impl(ctx):
     # Return the provider with result, visible to other rules.
     return [NumberInfo(number = result)]
 
-sum = rule(
+_sum = rule(
     implementation = _impl,
     attrs = {
         "number": attr.int(default = 1),
         "deps": attr.label_list(),
+        "out": attr.output(),
     },
-    outputs = {"out": "%{name}.sum"},
 )
+
+def sum(**kwargs):
+    _sum(out = "{name}.sum".format(**kwargs), **kwargs)

--- a/rules/predeclared_outputs/hash.bzl
+++ b/rules/predeclared_outputs/hash.bzl
@@ -46,7 +46,7 @@ def _word_hashes_impl(ctx):
 # Since we are not returning a DefaultInfo provider with a files= field,
 # all the predeclared outputs will be built when the target is requested.
 
-word_hashes = rule(
+_word_hashes = rule(
     implementation = _word_hashes_impl,
     attrs = {
         "dictionary": attr.label(
@@ -58,6 +58,9 @@ word_hashes = rule(
             doc = "A list of files named \"<word>.md5\", where \"<word>\" " +
                   "is in the dictionary.",
         ),
+        "manifest": attr.output(),
     },
-    outputs = {"manifest": "%{name}.manifest"},
 )
+
+def word_hashes(**kwargs):
+    _word_hashes(manifest = "{name}.manifest".format(**kwargs), **kwargs)


### PR DESCRIPTION
The `outputs` parameter of rule is deprecated. Hence don't use it in
examples where people are supposed to copy'n'paste from.

Documentation: https://docs.bazel.build/versions/main/skylark/rules.html#deprecated-predeclared-outputs
