### PR TITLE
Fix bad path in cpp-tutorial

### DIFF
--- a/cpp-tutorial/stage1/README.md
+++ b/cpp-tutorial/stage1/README.md
@@ -12,12 +12,12 @@ cc_binary(
 )
 ```
 
-To build this example you use
+To build this example, use
 ```
 bazel build //main:hello-world
 ```
 
-If the build is successful, Bazel prints the following output:
+If the build is successful, Bazel prints the output similar to
 ```
 ____Loading complete.  Analyzing...
 ____Found 1 target...
@@ -28,3 +28,14 @@ ____Elapsed time: 0,400s, Critical Path: 0,01s
 ```
 
 In the run log above you can see where the executable was built so you can locate it and use it.
+
+You can also get the output path with the bazel cquery command. For
+example, the command below would print the path to the output file. This
+is a useful technique for use in scripts, where you do not want to parse the
+`blaze build` output.
+
+```
+bazel cquery --output=starlark \
+  --starlark:expr="' '.join([f.path for f in target.files.to_list()])" \
+  //main:hello-world
+```

--- a/cpp-tutorial/stage2/README.md
+++ b/cpp-tutorial/stage2/README.md
@@ -24,11 +24,7 @@ cc_binary(
 )
 ```
 
-To build this example you use (notice that 3 slashes are required in windows)
+To build this example, use
 ```
 bazel build //main:hello-world
-
-# In Windows, note the three slashes
-
-bazel build ///main:hello-world
 ```

--- a/cpp-tutorial/stage3/README.md
+++ b/cpp-tutorial/stage3/README.md
@@ -26,11 +26,7 @@ cc_binary(
 )
 ```
 
-To build this example you use (notice that 3 slashes are required in windows)
+To build this example, use
 ```
 bazel build //main:hello-world
-
-# In Windows, note the three slashes
-
-bazel build ///main:hello-world
 ```


### PR DESCRIPTION
Fixes #198.

Also adds a hint about using cquery to find the path of the final executable.