### PR TITLE
Set specific bazel version number for "Bazel Rules" job

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -137,7 +137,7 @@ tasks:
   rules-linux:
     name: "Bazel Rules"
     platform: ubuntu1804
-    bazel: "4.2.2"
+    bazel: "latest"
     working_directory: rules
     build_targets:
     - "..."
@@ -155,7 +155,7 @@ tasks:
   rules-macos:
     name: "Bazel Rules"
     platform: macos
-    bazel: "4.2.2"    
+    bazel: "latest"    
     working_directory: rules
     build_targets:
     - "..."
@@ -173,7 +173,7 @@ tasks:
   rules-windows:
     name: "Bazel Rules"
     platform: windows
-    bazel: "4.2.2"    
+    bazel: "latest"    
     working_directory: rules
     build_targets:
     - "..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -137,6 +137,7 @@ tasks:
   rules-linux:
     name: "Bazel Rules"
     platform: ubuntu1804
+    bazel: "4.2.2"
     working_directory: rules
     build_targets:
     - "..."
@@ -154,6 +155,7 @@ tasks:
   rules-macos:
     name: "Bazel Rules"
     platform: macos
+    bazel: "4.2.2"    
     working_directory: rules
     build_targets:
     - "..."
@@ -171,6 +173,7 @@ tasks:
   rules-windows:
     name: "Bazel Rules"
     platform: windows
+    bazel: "4.2.2"    
     working_directory: rules
     build_targets:
     - "..."


### PR DESCRIPTION
This will skip testing those jobs with Bazel@HEAD in downstream pipeline.
We can re-enable them in downstream when https://github.com/bazelbuild/bazel/issues/14361 is fixed.