### PR TITLE
Fix markdown link in README.txt

### DIFF
--- a/rules/starlark_configurations/read_attr_in_transition/README.md
+++ b/rules/starlark_configurations/read_attr_in_transition/README.md
@@ -8,9 +8,9 @@ $ bazel build :dont-do-transition # "value of some-string: abc"
 $ bazel build :do-transition # "value of some-string: abc-transitioned"
 ```
 
-Caveat: <b>You cannot read a 
+Caveat: <b>You cannot read a
 [configured attribute](https://docs.bazel.build/versions/master/configurable-attributes.html)
-in a rule transition.</b> This can create a dependency cycle between attribute 
+in a rule transition.</b> This can create a dependency cycle between attribute
 values and configuration. To see an example of this cycle, run the following:
 ```
 $ bazel build :will-break # error message

--- a/rules/starlark_configurations/read_attr_in_transition/README.md
+++ b/rules/starlark_configurations/read_attr_in_transition/README.md
@@ -8,10 +8,10 @@ $ bazel build :dont-do-transition # "value of some-string: abc"
 $ bazel build :do-transition # "value of some-string: abc-transitioned"
 ```
 
-Caveat: <b>You cannot read a [configured attribute]
-(https://docs.bazel.build/versions/master/configurable-attributes.html) in a
-rule transition.</b> This can create a dependency cycle between attribute values
-and configuration. To see an example of this cycle, run the following:
+Caveat: <b>You cannot read a 
+[configured attribute](https://docs.bazel.build/versions/master/configurable-attributes.html)
+in a rule transition.</b> This can create a dependency cycle between attribute 
+values and configuration. To see an example of this cycle, run the following:
 ```
 $ bazel build :will-break # error message
 ```


### PR DESCRIPTION
The line break between the `[configure attribute]` and the (link) itself broke markdown formatting.