### PR TITLE
Rewrite WORKSPACE text for 3p example and other typos.

### DIFF
--- a/cpp-tutorial/stage2/main/hello-greet.h
+++ b/cpp-tutorial/stage2/main/hello-greet.h
@@ -1,5 +1,5 @@
-#ifndef LIB_HELLO_GREET_H_
-#define LIB_HELLO_GREET_H_
+#ifndef MAIN_HELLO_GREET_H_
+#define MAIN_HELLO_GREET_H_
 
 #include <string>
 

--- a/third-party-dependencies/WORKSPACE
+++ b/third-party-dependencies/WORKSPACE
@@ -1,10 +1,23 @@
-# We cannot fully load a dependency without loading the source code of the transitive dependencies.
-# In addition we want that if a dependency appears as a direct dependency and also as a transitive dependency
-# the direct dependency is loaded first, in this way we have better control on which version is used in
-# case that it is defined with the same name but different version.
-# Because of that, we load the 3rd party dependencies in two steps. First we load only the source code of all
-# dependencies explicitly declared in our project. Then on a second step we do everything that is missing to
-# fully load the dependency (load transitive dependencies, registar rules or toolchains, etc.)
+# An example of the common pattern for loading dependencies.
+#
+# We cannot fully load a dependency without loading its transitive dependencies.
+# This set of dependencies could be large and change over time, so we do not
+# want to manage it in our own WORKSPACE.  The pattern we use is:
+#
+# - Rule sets declare a method to load their dependencies.
+# - We load that method and call it.
+# - This pattern, of course, is repeated at each level.
+#
+# We also want some fine grained control of diamond dependencies. That is,
+# when we have a direct dependency on a rule set, but it is also a transitive
+# dependency of one of our dependencies, we would like to make sure we always
+# get the version we specify, rather than the one another rule set might.
+# To ensure that, we load the 3rd party dependencies in several phases.
+#
+# First, we import the all rules we depend on directly.
+# Then, for each of our dependencies
+#   - load and run their dependency loader method.
+#   - register any toolchains they might provide which we intend to use.
 
 load("//third_party:third_party.bzl", "load_third_party_libraries")
 


### PR DESCRIPTION
This PR pulls together a bunch of stale PRs that were typo or nit corrections.

- rewrite the description of the dependency loading idiom. Inspired by #236.
- Fix a header guard (from #122)