### PR TITLE
Add configuration tests back to CI

### DIFF
--- a/.bazelci/configurations.yml
+++ b/.bazelci/configurations.yml
@@ -39,6 +39,8 @@ configurations: &configurations
   - "-//cc_test/..."
   test_targets:
   - "..."
+  # TODO: why is this crashing bazel?
+  - "-//cc_test/..."
 
 #
 # Finally, the cross product of tests X platforms X bazel release

--- a/.bazelci/configurations.yml
+++ b/.bazelci/configurations.yml
@@ -37,8 +37,8 @@ configurations: &configurations
   - "-//cc_binary_selectable_copts:app_with_feature2_native_binary"
   # TODO: why is this crashing bazel?
   - "-//cc_test/..."
-  test_targets:
-  - "..."
+  # test_targets:
+  # - "..."
   # TODO: why is this crashing bazel?
   - "-//cc_test/..."
 

--- a/.bazelci/configurations.yml
+++ b/.bazelci/configurations.yml
@@ -1,0 +1,81 @@
+#
+# Bazel releases
+#
+lts: &lts
+  bazel: latest
+
+rolling: &rolling
+  bazel: rolling
+
+#
+# Commmon features by platform
+#
+linux: &linux
+  platform: ubuntu1804
+
+macos: &macos
+  platform: macos
+
+windows: &windows
+  platform: windows
+
+#
+# Test sets
+#
+configurations: &configurations
+  working_directory: ../configurations
+  build_targets:
+  - "..."
+  # These targets demonstrate failures: they're never meant to build.
+  - "-//read_attr_in_transition:will-break"
+  -"-//cc_binary_selectable_copts:app_forgets_to_set_features"
+   # These targest are not supposed to build at the top level: only as
+  # dependencies of other targets.
+  -"-//cc_binary_selectable_copts:lib"
+  - "-//cc_binary_selectable_copts:app_forgets_to_set_features_native_binary"
+  - "-//cc_binary_selectable_copts:app_with_feature1_native_binary"
+  - "-//cc_binary_selectable_copts:app_with_feature2_native_binary"
+  # TODO: why is this crashing bazel?
+  - "-//cc_test/..."
+  test_targets:
+  - "..."
+
+#
+# Finally, the cross product of tests X platforms X bazel release
+#
+tasks:
+  configs_linux_lts:
+    name: configs_linux_lts
+    <<: *linux
+    <<: *lts
+    <<: *configurations
+  configs_linux_latest:
+    name: configs_linux_latest
+    <<: *linux
+    <<: *rolling
+    <<: *configurations
+  configs_macos_lts:
+    name: configs_macos_lts
+    <<: *macos
+    <<: *lts
+    <<: *configurations
+  configs_macos_latest:
+    name: configs_macos_latest
+    <<: *macos
+    # It seems there is no rolling Bazel for macos.
+    bazel: last_green
+    <<: *configurations
+  configs_windows_lts:
+    name: configs_windows_lts
+    <<: *windows
+    <<: *lts
+    working_directory: ../configurations
+    build_targets:
+    - "..."
+  configs_windows_latest:
+    name: configs_windows_latest
+    <<: *windows
+    <<: *rolling
+    working_directory: ../configurations
+    build_targets:
+    - "..."

--- a/.bazelci/configurations.yml
+++ b/.bazelci/configurations.yml
@@ -28,10 +28,10 @@ configurations: &configurations
   - "..."
   # These targets demonstrate failures: they're never meant to build.
   - "-//read_attr_in_transition:will-break"
-  -"-//cc_binary_selectable_copts:app_forgets_to_set_features"
+  - "-//cc_binary_selectable_copts:app_forgets_to_set_features"
    # These targest are not supposed to build at the top level: only as
   # dependencies of other targets.
-  -"-//cc_binary_selectable_copts:lib"
+  - "-//cc_binary_selectable_copts:lib"
   - "-//cc_binary_selectable_copts:app_forgets_to_set_features_native_binary"
   - "-//cc_binary_selectable_copts:app_with_feature1_native_binary"
   - "-//cc_binary_selectable_copts:app_with_feature2_native_binary"

--- a/.bazelci/configurations.yml
+++ b/.bazelci/configurations.yml
@@ -71,13 +71,10 @@ tasks:
     name: configs_windows_lts
     <<: *windows
     <<: *lts
-    working_directory: ../configurations
-    build_targets:
-    - "..."
+    <<: *configurations
   configs_windows_latest:
     name: configs_windows_latest
     <<: *windows
     <<: *rolling
-    working_directory: ../configurations
-    build_targets:
-    - "..."
+    <<: *configurations
+

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,6 @@
 imports:
 - android.yml
+- configurations.yml
 - misc.yml
 - rules.yml
 - tutorials.yml

--- a/.bazelci/rules.yml
+++ b/.bazelci/rules.yml
@@ -29,23 +29,6 @@ basics: &basics
   test_targets:
   - "..."
 
-# TODO(bazel-configurability-team): Make these work again.
-configurations: &configurations
-  working_directory: ../configurations
-  build_targets:
-  - "..."
-  - "-//configurations/read_attr_in_transition:will-break"
-  # These targest are not supposed to build at the top level without flags being set
-  - "-//configurations/cc_binary_selectable_copts:app_forgets_to_set_features"
-  - "-//configurations/cc_binary_selectable_copts:app_forgets_to_set_features_native_binary"
-  - "-//configurations/cc_binary_selectable_copts:app_with_feature1_native_binary"
-  - "-//configurations/cc_binary_selectable_copts:app_with_feature2_native_binary"
-  - "-//configurations/cc_binary_selectable_copts:lib"
-  # TODO(#160) renable this target when split_attr logic is released
-  - "-//configurations/multi_arch_binary:foo"
-  test_targets:
-  - "..."
-
 #
 # Finally, the cross product of tests X platforms X bazel release
 #

--- a/configurations/attaching_transitions_to_rules/defs.bzl
+++ b/configurations/attaching_transitions_to_rules/defs.bzl
@@ -6,36 +6,36 @@ load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 def _blue_impl(settings, attr):
     _ignore = settings, attr
 
-    return {"//configurations/attaching_transitions_to_rules:color": "blue"}
+    return {"//attaching_transitions_to_rules:color": "blue"}
 
 blue_transition = transition(
     implementation = _blue_impl,
     inputs = [],
-    outputs = ["//configurations/attaching_transitions_to_rules:color"],
+    outputs = ["//attaching_transitions_to_rules:color"],
 )
 
 def _red_impl(settings, attr):
     _ignore = settings, attr
 
-    return {"//configurations/attaching_transitions_to_rules:color": "red"}
+    return {"//attaching_transitions_to_rules:color": "red"}
 
 red_transition = transition(
     implementation = _red_impl,
     inputs = [],
-    outputs = ["//configurations/attaching_transitions_to_rules:color"],
+    outputs = ["//attaching_transitions_to_rules:color"],
 )
 
 def _impl(ctx):
-    # Access the value of //configurations/attaching_transitions_to_rules:color for the target (blue).
+    # Access the value of //attaching_transitions_to_rules:color for the target (blue).
     print("shirt color: " + ctx.attr._color[BuildSettingInfo].value)
 
-    # Access the value of //configurations/attaching_transitions_to_rules:color for the transitioned dep (red).
+    # Access the value of //attaching_transitions_to_rules:color for the transitioned dep (red).
     # Note that you have to index by [0] here for the transitioned dep and you don't need to
     # do so below - this is because attribute-attached transitions can transition to multiple
     # new configurations so you must specify which one you want.
     print("sleeve color: " + ctx.attr.sleeve[0][BuildSettingInfo].value)
 
-    # Access the value of //configurations/attaching_transitions_to_rules:color for the non-transitioned dep (blue).
+    # Access the value of //attaching_transitions_to_rules:color for the non-transitioned dep (blue).
     print("back color: " + ctx.attr.back[BuildSettingInfo].value)
     return []
 

--- a/configurations/basic_build_setting/README.md
+++ b/configurations/basic_build_setting/README.md
@@ -8,5 +8,5 @@ This is an example of defining and instantiating your own build setting from scr
 To test it out, cd to this directory and run the following:
 ```
 $ bazel build :today # => "HOT"
-$ bazel build :today --//configurations/basic_build_setting:coffee-temp=ICED # => "ICED"
+$ bazel build :today --//basic_build_setting:coffee-temp=ICED # => "ICED"
 ```

--- a/configurations/cc_binary_selectable_copts/BUILD
+++ b/configurations/cc_binary_selectable_copts/BUILD
@@ -1,7 +1,7 @@
 # This load statement replaces the native cc_binary (which has no "set_features"
 # attribute) with a macro that strings together the logic to make that work,
 # then passes everything else back to the native cc_binary.
-load(":defs.bzl", "transition_rule", "cc_binary")
+load(":defs.bzl", "cc_binary", "transition_rule")
 
 # To see what this does, try "$ bazel run //:app_with_feature1".
 cc_binary(
@@ -22,20 +22,20 @@ cc_binary(
 # This binary "forgets" to set any features, so we have it fail with
 # a descriptive message.
 cc_binary(
-   name = "app_forgets_to_set_features",
-   srcs = ["main.cc"],
-   deps = [":lib"],
+    name = "app_forgets_to_set_features",
+    srcs = ["main.cc"],
+    deps = [":lib"],
 )
 
 # The library only builds if some feature is requested.
 cc_library(
-   name = "lib",
-   srcs = ["lib.cc"],
-   copts = select(
-       {
-           "//configurations/cc_binary_selectable_copts/custom_settings:feature1": ["-Dfeature1"],
-           "//configurations/cc_binary_selectable_copts/custom_settings:feature2": ["-Dfeature2"],
-       },
-       no_match_error = "You must explicitly set which features you want!",
-   ),
+    name = "lib",
+    srcs = ["lib.cc"],
+    copts = select(
+        {
+            "//cc_binary_selectable_copts/custom_settings:feature1": ["-Dfeature1"],
+            "//cc_binary_selectable_copts/custom_settings:feature2": ["-Dfeature2"],
+        },
+        no_match_error = "You must explicitly set which features you want!",
+    ),
 )

--- a/configurations/cc_binary_selectable_copts/defs.bzl
+++ b/configurations/cc_binary_selectable_copts/defs.bzl
@@ -3,7 +3,7 @@ def _copt_transition_impl(settings, attr):
 
     # settings provides read access to existing flags. But
     # this transition doesn't need to read any flags.
-    return {"//configurations/cc_binary_selectable_copts/custom_settings:mycopts": attr.set_features}
+    return {"//cc_binary_selectable_copts/custom_settings:mycopts": attr.set_features}
 
 # This defines a Starlark transition and which flags it reads and
 # writes. In this case we don't need to read any flags - we
@@ -12,7 +12,7 @@ def _copt_transition_impl(settings, attr):
 _copt_transition = transition(
     implementation = _copt_transition_impl,
     inputs = [],
-    outputs = ["//configurations/cc_binary_selectable_copts/custom_settings:mycopts"],
+    outputs = ["//cc_binary_selectable_copts/custom_settings:mycopts"],
 )
 
 # The implementation of transition_rule: all this does is copy the

--- a/configurations/label_typed_build_setting/README.md
+++ b/configurations/label_typed_build_setting/README.md
@@ -22,7 +22,8 @@ Target A --------------> Label Flag X --------------> Target B
 
 To test it out, cd to this directory and run the following:
 ```
-$ bazel build :my-toolbox # "Using a hammer."
-$ bazel build :my-toolbox --//configurations/label_typed_build_setting:tool= \
-	//configurations/label_typed_build_setting:screwdriver # "Using a screwdriver."
+$ bazel build :my-toolbox
+# "Using a hammer."
+$ bazel build :my-toolbox --//label_typed_build_setting:tool=//label_typed_build_setting:screwdriver
+# "Using a screwdriver."
 ```

--- a/configurations/label_typed_build_setting/defs.bzl
+++ b/configurations/label_typed_build_setting/defs.bzl
@@ -12,7 +12,7 @@ toolbox = rule(
         # Depend on the label flag.
         # Optionally use a private variable (one prefixed with "_" to prevent
         # target writers from changing what flag is read.
-        "_tool": attr.label(default = "//configurations/label_typed_build_setting:tool"),
+        "_tool": attr.label(default = ":tool"),
     },
 )
 

--- a/configurations/read_attr_in_transition/defs.bzl
+++ b/configurations/read_attr_in_transition/defs.bzl
@@ -2,17 +2,17 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 def _transition_impl(settings, attr):
-    new_val = settings["//configurations/read_attr_in_transition:some-string"]
+    new_val = settings["//read_attr_in_transition:some-string"]
 
     if attr.do_transition:
         new_val = new_val + "-transitioned"
 
-    return {"//configurations/read_attr_in_transition:some-string": new_val}
+    return {"//read_attr_in_transition:some-string": new_val}
 
 my_transition = transition(
     implementation = _transition_impl,
-    inputs = ["//configurations/read_attr_in_transition:some-string"],
-    outputs = ["//configurations/read_attr_in_transition:some-string"],
+    inputs = ["//read_attr_in_transition:some-string"],
+    outputs = ["//read_attr_in_transition:some-string"],
 )
 
 def _impl(ctx):
@@ -25,7 +25,7 @@ my_rule = rule(
     cfg = my_transition,
     attrs = {
         "do_transition": attr.bool(),
-        "_some_string": attr.label(default = Label("//configurations/read_attr_in_transition:some-string")),
+        "_some_string": attr.label(default = Label("//read_attr_in_transition:some-string")),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),

--- a/configurations/select_on_build_setting/README.md
+++ b/configurations/select_on_build_setting/README.md
@@ -3,6 +3,6 @@ This is an example of how to read build settings in a [configurable attribute](h
 To test it out, cd to this directory and run the following
 ```
 $ bazel build :harvest # => "We're harvesting apples!"
-$ bazel build :harvest --//configurations/select_on_build_setting:season=summer # => "We're harvesting cherries!"
-$ bazel build :harvest --//configurations/select_on_build_setting:season=fall # => "We're harvesting pumpkins!"
+$ bazel build :harvest --//select_on_build_setting:season=summer # => "We're harvesting cherries!"
+$ bazel build :harvest --//select_on_build_setting:season=fall # => "We're harvesting pumpkins!"
 ```

--- a/configurations/use_skylib_build_setting/BUILD
+++ b/configurations/use_skylib_build_setting/BUILD
@@ -8,8 +8,8 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load(":defs.bzl", "dessert")
 
-# This can be set on the command line by setting 
-# //configurations/use_skylib_build_setting:flavor=<flavor>.
+# This can be set on the command line by setting
+# //use_skylib_build_setting:flavor=<flavor>.
 # We declare here that its default value is "strawberry".
 string_flag(name = "flavor", build_setting_default = "strawberry")
 

--- a/configurations/use_skylib_build_setting/README.md
+++ b/configurations/use_skylib_build_setting/README.md
@@ -5,5 +5,5 @@ To test it out, cd into this directory and run the following:
 
 ```
 $ bazel build :ice-cream // => "flavor: strawberry"
-$ bazel build :ice-cream --//configurations/use_skylib_build_settings:flavor=rocky-road => "flavor: rocky-road"
+$ bazel build :ice-cream --//use_skylib_build_settings:flavor=rocky-road => "flavor: rocky-road"
 ```

--- a/configurations/use_skylib_build_setting/defs.bzl
+++ b/configurations/use_skylib_build_setting/defs.bzl
@@ -2,7 +2,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 def _impl(ctx):
-    # Access the value of --//configurations/use_skylib_build_setting:flavor for the target.
+    # Access the value of --//use_skylib_build_setting:flavor for the target.
     print("flavor: " + ctx.attr._flavor[BuildSettingInfo].value)
     return []
 


### PR DESCRIPTION
https://github.com/bazelbuild/examples/commit/e5e9d051202565343708dcde2baa0010cb083731 refactored the WORKSPACES (so labels resolve differently).

Fixes https://github.com/bazelbuild/examples/issues/247