### PR TITLE
Polish the Bzlmod examples

### DIFF
--- a/.bazelci/bzlmod.yml
+++ b/.bazelci/bzlmod.yml
@@ -1,7 +1,6 @@
 ---
 matrix:
   all_platform: ["ubuntu1804", "macos", "windows"]
-  unix_platform: ["ubuntu1804", "macos"]
 
 tasks:
   01-depend_on_bazel_module:
@@ -10,7 +9,7 @@ tasks:
     platform: ${{ all_platform }}
     working_directory: ../bzlmod/01-depend_on_bazel_module
     build_flags:
-    - "--experimental_enable_bzlmod"
+    - "--enable_bzlmod"
     build_targets:
     - "//:main"
   02-override_bazel_module:
@@ -19,7 +18,7 @@ tasks:
     platform: ${{ all_platform }}
     working_directory: ../bzlmod/02-override_bazel_module
     build_flags:
-    - "--experimental_enable_bzlmod"
+    - "--enable_bzlmod"
     build_targets:
     - "//:main"
   03-introduce_dependencies_with_module_extension:
@@ -28,7 +27,7 @@ tasks:
     platform: ${{ all_platform }}
     working_directory: ../bzlmod/03-introduce_dependencies_with_module_extension
     build_flags:
-    - "--experimental_enable_bzlmod"
+    - "--enable_bzlmod"
     build_targets:
     - "//:city_count"
     - "//:emoji_count"
@@ -40,50 +39,24 @@ tasks:
       MY_SHELL_BIN_PATH: /foo/bar/sh
     working_directory: ../bzlmod/04-local_config_and_register_toolchains
     build_flags:
-    - "--experimental_enable_bzlmod"
+    - "--enable_bzlmod"
     build_targets:
     - "//:get_sh_path"
   05-integrate_third_party_package_manager:
     name: "Integrate third party package manager"
     bazel: last_green
-    platform: ${{ unix_platform }}
-    environment:
-      LIBRARIAN_BIN_PATH: $PWD/bzlmod/utils/librarian/librarian.py
+    platform: ${{ all_platform }}
     working_directory: ../bzlmod/05-integrate_third_party_package_manager
     build_flags:
-    - "--experimental_enable_bzlmod"
-    build_targets:
-    - "//:check_books"
-  05-integrate_third_party_package_manager_windows:
-    name: "Integrate third party package manager"
-    bazel: last_green
-    platform: windows
-    environment:
-      LIBRARIAN_BIN_PATH: $PWD/bzlmod/utils/librarian/librarian.cmd
-    working_directory: ../bzlmod/05-integrate_third_party_package_manager
-    build_flags:
-    - "--experimental_enable_bzlmod"
+    - "--enable_bzlmod"
     build_targets:
     - "//:check_books"
   06-specify_dev_dependency:
     name: "Specify dev dependency"
     bazel: last_green
-    platform: ${{ unix_platform }}
-    environment:
-      LIBRARIAN_BIN_PATH: $PWD/bzlmod/utils/librarian/librarian.py
+    platform: ${{ all_platform }}
     working_directory: ../bzlmod/06-specify_dev_dependency
     build_flags:
-    - "--experimental_enable_bzlmod"
-    build_targets:
-    - "//:check_books"
-  06-specify_dev_dependency_windows:
-    name: "Specify dev dependency"
-    bazel: last_green
-    platform: windows
-    environment:
-      LIBRARIAN_BIN_PATH: $PWD/bzlmod/utils/librarian/librarian.cmd
-    working_directory: ../bzlmod/06-specify_dev_dependency
-    build_flags:
-    - "--experimental_enable_bzlmod"
+    - "--enable_bzlmod"
     build_targets:
     - "//:check_books"

--- a/bzlmod/01-depend_on_bazel_module/README.md
+++ b/bzlmod/01-depend_on_bazel_module/README.md
@@ -4,8 +4,9 @@ This is an example on how to introduce dependencies on Bazel modules in the MODU
 - referencing the dependency with a given repository name instead of the module name
 
 To test it out, `cd` into this directory and run the following:
-```
-$ export USE_BAZEL_VERSION=last_green
-$ bazelisk build --experimental_enable_bzlmod //:main
-$ GLOG_logtostderr=1 ./bazel-bin/main
+
+```bash
+export USE_BAZEL_VERSION=last_green
+bazelisk build --experimental_enable_bzlmod //:main
+GLOG_logtostderr=1 ./bazel-bin/main
 ```

--- a/bzlmod/02-override_bazel_module/README.md
+++ b/bzlmod/02-override_bazel_module/README.md
@@ -8,8 +8,9 @@ This is an example on how to override Bazel module dependencies in the MODULE.ba
 Note that the final source tree after overriding must contain a MODULE.bazel file at the root.
 
 To test it out, `cd` into this directory and run the following:
-```
-$ export USE_BAZEL_VERSION=last_green
-$ bazelisk build --experimental_enable_bzlmod //:main
-$ GLOG_logtostderr=1 ./bazel-bin/main
+
+```bash
+export USE_BAZEL_VERSION=last_green
+bazelisk build --experimental_enable_bzlmod //:main
+GLOG_logtostderr=1 ./bazel-bin/main
 ```

--- a/bzlmod/03-introduce_dependencies_with_module_extension/README.md
+++ b/bzlmod/03-introduce_dependencies_with_module_extension/README.md
@@ -6,8 +6,9 @@ This is an example on how to introduce dependencies by invoking external reposit
 - allowing accessing a repository from the root module under a different name.
 
 To test it out, `cd` into this directory and run the following:
-```
-$ export USE_BAZEL_VERSION=last_green
-$ bazelisk build --experimental_enable_bzlmod //:city_count //:emoji_count
-$ cat bazel-bin/city_number bazel-bin/emoji_number
+
+```bash
+export USE_BAZEL_VERSION=last_green
+bazelisk build --experimental_enable_bzlmod //:city_count //:emoji_count
+cat bazel-bin/city_number bazel-bin/emoji_number
 ```

--- a/bzlmod/04-local_config_and_register_toolchains/README.md
+++ b/bzlmod/04-local_config_and_register_toolchains/README.md
@@ -4,9 +4,10 @@ This is an example on how to generate local config repos and register toolchains
 - registering the generated toolchain in the MODULE.bazel file.
 
 To test it out, `cd` into this directory and run the following:
-```
-$ export USE_BAZEL_VERSION=last_green
-$ export MY_SHELL_BIN_PATH=/foo/bar/sh
-$ bazelisk build --experimental_enable_bzlmod //:get_sh_path
-$ cat ./bazel-bin/result
+
+```bash
+export USE_BAZEL_VERSION=last_green
+export MY_SHELL_BIN_PATH=/foo/bar/sh
+bazelisk build --enable_bzlmod //:get_sh_path
+cat ./bazel-bin/result
 ```

--- a/bzlmod/05-integrate_third_party_package_manager/README.md
+++ b/bzlmod/05-integrate_third_party_package_manager/README.md
@@ -6,21 +6,23 @@ Our goal is to integrate it with module extension to select and fetch books, the
 
 It covers the following topics:
 
- - Defining module extension tags.
- - Using module extension tags in MODULE.bazel files.
- - Collecting transitive dependency info from module extension tags.
- - Invoking the package manager to resolve dependencies.
- - Generating repositories for resolved dependencies.
+- Defining module extension tags.
+- Using module extension tags in MODULE.bazel files.
+- Collecting transitive dependency info from module extension tags.
+- Invoking the package manager to resolve dependencies.
+- Generating repositories for resolved dependencies.
 
 To test it out, `cd` into this directory and run the following:
+
+```bash
+export USE_BAZEL_VERSION=last_green
+bazelisk build --enable_bzlmod //:check_books
+cat ./bazel-bin/books
 ```
-$ export USE_BAZEL_VERSION=last_green
-$ export LIBRARIAN_BIN_PATH=$PWD/../utils/librarian/librarian.py
-$ bazelisk build --experimental_enable_bzlmod //:check_books
-$ cat ./bazel-bin/books
-```
+
 The newest editions of all required books should be fetched, expected output:
-```
+
+```bash
 $ cat bazel-bin/books
 Book Name: hamlet
 Edition: 2005.1

--- a/bzlmod/06-specify_dev_dependency/README.md
+++ b/bzlmod/06-specify_dev_dependency/README.md
@@ -6,15 +6,17 @@ This is an example on how to specify dev dependencies with Bzlmod. It covers the
 Dev dependencies only take effect when the current module is the root module, and are ignored if the current module is used as a dependency.
 
 To test it out, `cd` into this directory and run the following:
+
+```bash
+export USE_BAZEL_VERSION=last_green
+bazelisk build --enable_bzlmod //:check_books
+cat ./bazel-bin/books
 ```
-$ export USE_BAZEL_VERSION=last_green
-$ export LIBRARIAN_BIN_PATH=$PWD/../utils/librarian/librarian.py
-$ bazelisk build --experimental_enable_bzlmod //:check_books
-$ cat ./bazel-bin/books
-```
+
 Bazel skylib version 1.1.1 should be used and the newest editions of all required books that're not dev dependencies should be fetched, expected output:
-```
-$ bazelisk build --experimental_enable_bzlmod //:check_books
+
+```bash
+$ bazelisk build --enable_bzlmod //:check_books
 ...
 DEBUG: <path to examples dir>/examples/bzlmod/06-specify_dev_dependency/BUILD:3:6: Bazel Skylib version: 1.1.1
 ...

--- a/bzlmod/utils/librarian/librarian.bzl
+++ b/bzlmod/utils/librarian/librarian.bzl
@@ -1,9 +1,11 @@
+def _get_librarian_path(ctx):
+    if ctx.os.name.find("windows") != -1:
+        return ctx.path(Label("//:librarian.cmd"))
+    else:
+        return ctx.path(Label("//:librarian.py"))
+
 def _fetch_book_impl(repository_ctx):
-    librarian = repository_ctx.os.environ.get("LIBRARIAN_BIN_PATH")
-    if not librarian:
-        fail("LIBRARIAN_BIN_PATH is not set!")
-    if not repository_ctx.path(librarian).exists:
-        fail("Path %s doesn't exist!" % librarian)
+    librarian = _get_librarian_path(repository_ctx)
     book_name = repository_ctx.attr.name.split(".")[-1]
     edition = repository_ctx.attr.edition
     result = repository_ctx.execute([librarian, "fetch", "%s@%s" % (book_name, edition)])
@@ -19,16 +21,13 @@ filegroup(
 
 fetch_book = repository_rule(
     implementation = _fetch_book_impl,
-    environ = ["LIBRARIAN_BIN_PATH"],
     attrs = {
         "edition": attr.string(),
     },
 )
 
 def _librarian_extension_impl(module_ctx):
-    librarian = module_ctx.os.environ.get("LIBRARIAN_BIN_PATH")
-    if not librarian:
-        fail("LIBRARIAN_BIN_PATH is not set!")
+    librarian = _get_librarian_path(module_ctx)
     books = []
     for mod in module_ctx.modules:
         for book in mod.tags.book:
@@ -49,7 +48,5 @@ book = tag_class(attrs={
 
 librarian_extension = module_extension(
     implementation = _librarian_extension_impl,
-    # TODO: module_extension should also support the "environ" attribute.
-    # environ = ["LIBRARIAN_BIN_PATH"],
     tag_classes = {"book": book},
 )


### PR DESCRIPTION
- Renamed `--experimental_enable_bzlmod` to `--enable_bzlmod`
- Removed the need of `LIBRARIAN_BIN_PATH` env var
- Fix some markdown warnings

This will also fix [the downstream failure](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2728#01845f52-8d7b-42e4-8232-3589b9e8575d) which was caused by a wrong `LIBRARIAN_BIN_PATH` path.