### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,49 +4,49 @@ A collection of examples of how to use the Bazel build system.
 
 ## Introductory tutorials
 
-* [C++ basics](/tree/main/cpp-tutorial)
-* [Java basics](/tree/main/java-tutorial)
-* [End to End](/tree/main/tutorial)
-  <br/>A full end-to-end system with a backend, an Android app, and an iOS app.
-* [iOS basics](/tree/main/tutorial/ios-app)
-* [Using query](/tree/main/query-quickstart)
-  <br/>Working examples for [The Query quickstart](https://bazel.build/query/quickstart)
+ * [C++ basics](/cpp-tutorial)
+ * [Java basics](/java-tutorial)
+ * [End to End](/tutorial)
+   <br/>A full end-to-end system with a backend, an Android app, and an iOS app.
+ * [iOS basics](/tutorial/ios-app)
+ * [Using query](/query-quickstart)
+   <br/>Working examples for [The Query quickstart](https://bazel.build/query/quickstart)
 
-## Example cookbook
+ ## Example cookbook
 
-### General
+ ### General
 
-* [Using bzlmod](/tree/main/bzlmod)
-* [How to generate source code from a rule and include it in a library](/tree/main/rules/generating_code)
+ * [Using bzlmod](/bzlmod)
+ * [How to generate source code from a rule and include it in a library](/rules/generating_code)
 
-### [Android](/tree/main/android)
+ ### [Android](/tree/main/android)
 
-* [Using Android Jetpack Compose](/tree/main/firebase-cloud-messaging)
-* [Using Firebase Cloud Messaging](/tree/main/jetpack-compose)
-* [Using the NDK](/tree/main/android/ndk)
-* [Using Roboelectic tests and Kotlin](/tree/main/android/robolectric-testing)
+ * [Using Android Jetpack Compose](/firebase-cloud-messaging)
+ * [Using Firebase Cloud Messaging](/jetpack-compose)
+ * [Using the NDK](/android/ndk)
+ * [Using Roboelectic tests and Kotlin](/android/robolectric-testing)
 
-### Java
+ ### Java
 
-* [Using Java with Maven](/tree/main/java-maven)
+ * [Using Java with Maven](/java-maven)
 
-### [Rule writing](/tree/main/rules)
+ ### [Rule writing](/rules)
 
-* [Accessing attributes of a rule](/tree/main/rules/attributes)
-* [A rule with both explict and implicit outputs](/tree/main/rules/implicit_output)
-* [Creating a simple `*_test` rule](/tree/main/rules/test_rule)
-* [Rules that change the build flags](/tree/main/configurations)
-* [Rules with implicit dependencies](/tree/main/rules/computed_dependencies)
-* [Using a macro wrapper to compute an output file name](/tree/main/rules/optional_provider)
-* [Using aspects](/tree/main/rules/aspect)
-* [Using ctx.actions.expand_template](/tree/main/rules/expand_template)
-* [Using ctx.actions.run_shell to wrap simple commands](/tree/main/rules/shell_command)
-* [Using ctx.actions.run to run a tool](/tree/main/rules/actions_run)
-* [Using ctx.actions.write to create a file at analysis time](/tree/main/rules/actions_write)
-* [Using depsets](/tree/main/rules/depsets)
-* [Using "Make" variables in your rules](/tree/main/make-variables)
-* [Using mandatory providers to ensure your dependencies are of the right type](/tree/main/rules/mandatory_provider)
-* [Using runfiles](/tree/main/rules/runfiles)
+ * [Accessing attributes of a rule](/rules/attributes)
+ * [A rule with both explict and implicit outputs](/rules/implicit_output)
+ * [Creating a simple `*_test` rule](/rules/test_rule)
+ * [Rules that change the build flags](/configurations)
+ * [Rules with implicit dependencies](/rules/computed_dependencies)
+ * [Using a macro wrapper to compute an output file name](/rules/optional_provider)
+ * [Using aspects](/rules/aspect)
+ * [Using ctx.actions.expand_template](/rules/expand_template)
+ * [Using ctx.actions.run_shell to wrap simple commands](/rules/shell_command)
+ * [Using ctx.actions.run to run a tool](/rules/actions_run)
+ * [Using ctx.actions.write to create a file at analysis time](/rules/actions_write)
+ * [Using depsets](/rules/depsets)
+ * [Using "Make" variables in your rules](/make-variables)
+ * [Using mandatory providers to ensure your dependencies are of the right type](/rules/mandatory_provider)
+ * [Using runfiles](/rules/runfiles)
 
 
 CI:


### PR DESCRIPTION
fix relatively link of this pr: https://github.com/bazelbuild/examples/pull/283#issue-1652405365

maybe no neeed to use `/tree/main/`, github URL of completion is `https://github.com/bazelbuild/examples/blob/main/tree/main/cpp-tutorial`, this link will get 404:
![image](https://user-images.githubusercontent.com/26135447/234473603-2918c065-c5d0-4efd-9f0a-883381d0278a.png)

should be `https://github.com/bazelbuild/examples/blob/main/cpp-tutorial`