### PR TITLE
Set --remote_download_outputs=all for some android examples

### DIFF
--- a/.bazelci/android.yml
+++ b/.bazelci/android.yml
@@ -54,18 +54,24 @@ tasks:
     name: "Android Jetpack Compose"
     platform: ubuntu1804
     working_directory: ../android/jetpack-compose
+    build_flags:
+      - "--remote_download_outputs=all"
     build_targets:
       - "//app/src/main:app"
   android-jetpack-compose-macos:
     name: "Android Jetpack Compose"
     platform: macos
     working_directory: ../android/jetpack-compose
+    build_flags:
+      - "--remote_download_outputs=all"
     build_targets:
       - "//app/src/main:app"
   android-jetpack-compose-windows:
     name: "Android Jetpack Compose"
     platform: windows
     working_directory: ../android/jetpack-compose
+    build_flags:
+      - "--remote_download_outputs=all"
     build_targets:
       - "//app/src/main:app"
   android-robolectric-testing-linux:


### PR DESCRIPTION
https://github.com/bazelbuild/continuous-integration/pull/1585 seems to break those builds