### PR TITLE
Partial revert of "Fix missing jni.h when cc toolchain resolution is enabled"

### DIFF
--- a/android/ndk/app/src/main/BUILD.bazel
+++ b/android/ndk/app/src/main/BUILD.bazel
@@ -17,7 +17,6 @@ android_library(
 cc_library(
     name = "jni_lib",
     srcs = ["cpp/native-lib.cpp"],
-    deps = ["@bazel_tools//tools/jdk:jni"],
 )
 
 android_binary(


### PR DESCRIPTION
jni.h must be coming from cc_toolchain. Adding it just obscures an underlying problem, when NDK toolchain isn't selected.