### PR TITLE
Fix CI for C++ toolchain resolution

### DIFF
--- a/.bazelci/tutorials.yml
+++ b/.bazelci/tutorials.yml
@@ -16,7 +16,6 @@ tasks:
       - "//android"
       - "//ios-app"
     build_flags:
-      - --platform_mappings=@build_bazel_rules_apple//:platform_mappings
       - --incompatible_enable_cc_toolchain_resolution # TODO: remove, testing on CI
   tutorial-windows:
     name: "Bazel end-to-end example"

--- a/.bazelci/tutorials.yml
+++ b/.bazelci/tutorials.yml
@@ -15,8 +15,6 @@ tasks:
       - "//backend"
       - "//android"
       - "//ios-app"
-    build_flags:
-      - --incompatible_enable_cc_toolchain_resolution # TODO: remove, testing on CI
   tutorial-windows:
     name: "Bazel end-to-end example"
     platform: windows

--- a/.bazelci/tutorials.yml
+++ b/.bazelci/tutorials.yml
@@ -15,6 +15,9 @@ tasks:
       - "//backend"
       - "//android"
       - "//ios-app"
+    build_flags:
+      - --platform_mappings=@build_bazel_rules_apple//:platform_mappings
+      - --incompatible_enable_cc_toolchain_resolution # TODO: remove, testing on CI
   tutorial-windows:
     name: "Bazel end-to-end example"
     platform: windows

--- a/tutorial/platform_mappings
+++ b/tutorial/platform_mappings
@@ -1,0 +1,120 @@
+platforms:
+  @build_bazel_apple_support//platforms:macos_x86_64
+    --cpu=darwin_x86_64
+
+  @build_bazel_apple_support//platforms:macos_arm64
+    --cpu=darwin_arm64
+
+  @build_bazel_apple_support//platforms:darwin_arm64e
+    --cpu=darwin_arm64e
+
+  @build_bazel_apple_support//platforms:ios_i386
+    --cpu=ios_i386
+
+  @build_bazel_apple_support//platforms:ios_x86_64
+    --cpu=ios_x86_64
+
+  @build_bazel_apple_support//platforms:ios_sim_arm64
+    --cpu=ios_sim_arm64
+
+  @build_bazel_apple_support//platforms:ios_armv7
+    --cpu=ios_armv7
+
+  @build_bazel_apple_support//platforms:ios_arm64
+    --cpu=ios_arm64
+
+  @build_bazel_apple_support//platforms:ios_arm64e
+    --cpu=ios_arm64e
+
+  @build_bazel_apple_support//platforms:tvos_x86_64
+    --cpu=tvos_x86_64
+
+  @build_bazel_apple_support//platforms:tvos_sim_arm64
+    --cpu=tvos_sim_arm64
+
+  @build_bazel_apple_support//platforms:tvos_arm64
+    --cpu=tvos_arm64
+
+  @build_bazel_apple_support//platforms:watchos_i386
+    --cpu=watchos_i386
+
+  @build_bazel_apple_support//platforms:watchos_x86_64
+    --cpu=watchos_x86_64
+
+  @build_bazel_apple_support//platforms:watchos_arm64
+    --cpu=watchos_arm64
+
+  @build_bazel_apple_support//platforms:watchos_armv7k
+    --cpu=watchos_armv7k
+
+  @build_bazel_apple_support//platforms:watchos_arm64_32
+    --cpu=watchos_arm64_32
+
+flags:
+  --cpu=darwin_x86_64
+  --apple_platform_type=macos
+    @build_bazel_apple_support//platforms:macos_x86_64
+
+  --cpu=darwin_arm64
+  --apple_platform_type=macos
+    @build_bazel_apple_support//platforms:macos_arm64
+
+  --cpu=darwin_arm64e
+  --apple_platform_type=macos
+    @build_bazel_apple_support//platforms:darwin_arm64e
+
+  --cpu=ios_i386
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_i386
+
+  --cpu=ios_x86_64
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_x86_64
+
+  --cpu=ios_sim_arm64
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_sim_arm64
+
+  --cpu=ios_armv7
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_armv7
+
+  --cpu=ios_arm64
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_arm64
+
+  --cpu=ios_arm64e
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_arm64e
+
+  --cpu=tvos_x86_64
+  --apple_platform_type=tvos
+    @build_bazel_apple_support//platforms:tvos_x86_64
+
+  --cpu=tvos_sim_arm64
+  --apple_platform_type=tvos
+    @build_bazel_apple_support//platforms:tvos_sim_arm64
+
+  --cpu=tvos_arm64
+  --apple_platform_type=tvos
+    @build_bazel_apple_support//platforms:tvos_arm64
+
+  --cpu=watchos_i386
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_i386
+
+  --cpu=watchos_x86_64
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_x86_64
+
+  --cpu=watchos_arm64
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_arm64
+
+  --cpu=watchos_armv7k
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_armv7k
+
+  --cpu=watchos_arm64_32
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_arm64_32


### PR DESCRIPTION
Apple rules are supported using `platform_mappings`. Unfortunately we need a copy, and cannot refer directly to the one provider by rules_apple. By default Bazel is looking for the file in root directory (so it's enough to just add the file).

The change passes CI with C++ toolchain resolution enabled on mac.