### PR TITLE
chore: enable buildifier check for module docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
       - id: buildifier
       - id: buildifier-lint
         args:
-          - --warnings=-module-docstring,-provider-params,-name-conventions,-unnamed-macro
+          - --warnings=-provider-params,-name-conventions,-unnamed-macro

--- a/bzlmod/03-introduce_dependencies_with_module_extension/deps.bzl
+++ b/bzlmod/03-introduce_dependencies_with_module_extension/deps.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def world_cities():

--- a/bzlmod/03-introduce_dependencies_with_module_extension/lib_a/deps.bzl
+++ b/bzlmod/03-introduce_dependencies_with_module_extension/lib_a/deps.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def emojis():

--- a/bzlmod/04-local_config_and_register_toolchains/local_config_sh.bzl
+++ b/bzlmod/04-local_config_and_register_toolchains/local_config_sh.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _is_windows(repository_ctx):
     """Returns true if the host OS is Windows."""
     return repository_ctx.os.name.startswith("windows")

--- a/bzlmod/04-local_config_and_register_toolchains/sh_path.bzl
+++ b/bzlmod/04-local_config_and_register_toolchains/sh_path.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _write_sh_path_impl(ctx):
     # Save the shell path to the given output file.
     sh_path = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path

--- a/bzlmod/05-integrate_third_party_package_manager/lib_a/deps.bzl
+++ b/bzlmod/05-integrate_third_party_package_manager/lib_a/deps.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@librarian//:librarian.bzl", "fetch_book")
 
 def fetch_book_for_lib_a():

--- a/bzlmod/05-integrate_third_party_package_manager/lib_b/deps.bzl
+++ b/bzlmod/05-integrate_third_party_package_manager/lib_b/deps.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@librarian//:librarian.bzl", "fetch_book")
 
 def fetch_book_for_lib_b():

--- a/bzlmod/06-specify_dev_dependency/lib_a/deps.bzl
+++ b/bzlmod/06-specify_dev_dependency/lib_a/deps.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@librarian//:librarian.bzl", "fetch_book")
 
 def deps():

--- a/bzlmod/utils/librarian/librarian.bzl
+++ b/bzlmod/utils/librarian/librarian.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _get_librarian_path(ctx):
     if ctx.os.name.find("windows") != -1:
         return ctx.path(Label("//:librarian.cmd"))

--- a/configurations/attaching_transitions_to_rules/defs.bzl
+++ b/configurations/attaching_transitions_to_rules/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 # Load the provider of the pre-made settings defined in bazel_skylib.
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 

--- a/configurations/basic_build_setting/defs.bzl
+++ b/configurations/basic_build_setting/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 TemperatureProvider = provider(fields = ["type"])
 
 temperatures = ["HOT", "LUKEWARM", "ICED"]

--- a/configurations/cc_binary_selectable_copts/defs.bzl
+++ b/configurations/cc_binary_selectable_copts/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _copt_transition_impl(_, attr):
     # settings provides read access to existing flags. But
     # this transition doesn't need to read any flags.

--- a/configurations/cc_test/defs.bzl
+++ b/configurations/cc_test/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 # We can transition on native options using this
 # //command_line_option:<option-name> syntax
 _BUILD_SETTING = "//command_line_option:test_arg"

--- a/configurations/label_typed_build_setting/defs.bzl
+++ b/configurations/label_typed_build_setting/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 ToolInfo = provider(fields = ["type"])
 
 # buildifier: disable=print

--- a/configurations/multi_arch_binary/defs.bzl
+++ b/configurations/multi_arch_binary/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _transition_impl(_, __):
     # Return a dict of dicts. The values are the updates to the configuration.
     # The keys are arbitrary helpful strings that can be used to access the split

--- a/configurations/read_attr_in_transition/defs.bzl
+++ b/configurations/read_attr_in_transition/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 # Load the provider of the pre-made settings defined in bazel_skylib.
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 

--- a/configurations/select_on_build_setting/defs.bzl
+++ b/configurations/select_on_build_setting/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 FruitInfo = provider(fields = ["type"])
 
 # buildifier: disable=print

--- a/configurations/transition_on_native_flag/defs.bzl
+++ b/configurations/transition_on_native_flag/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _transition_impl(_, attr):
     # Attaching the special prefix "//comand_line_option" to the name of a native
     # flag makes the flag available to transition on. The result of this transition

--- a/configurations/use_skylib_build_setting/defs.bzl
+++ b/configurations/use_skylib_build_setting/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 # Load the provider of the pre-made settings defined in bazel_skylib
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 

--- a/flags-parsing-tutorial/build_defs.bzl
+++ b/flags-parsing-tutorial/build_defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 BuildSettingInfo = provider()
 
 def _string_imp(ctx):

--- a/make-variables/testapp/defs.bzl
+++ b/make-variables/testapp/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _var_providing_rule_impl(ctx):
     return [
         platform_common.TemplateVariableInfo({

--- a/rules/depsets/foo.bzl
+++ b/rules/depsets/foo.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 FooFiles = provider("transitive_sources")
 
 def get_transitive_srcs(srcs, deps):

--- a/rules/executable/fortune.bzl
+++ b/rules/executable/fortune.bzl
@@ -1,9 +1,11 @@
-# A rule that generates a "fortune"-style executable for haikus. It takes haiku
-# files as inputs, and produces a data file consisting of their concatenation,
-# along with a shell script.
-#
-# To run, use
-#     bazel run //executable:bazel_haikus
+"""A rule that generates a "fortune"-style executable for haikus.
+
+It takes haiku
+files as inputs, and produces a data file consisting of their concatenation,
+along with a shell script.
+To run, use
+    bazel run //executable:bazel_haikus
+"""
 
 # The script content, with placeholders for the data file name and number of
 # haikus.

--- a/rules/implicit_output/hash.bzl
+++ b/rules/implicit_output/hash.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _impl(ctx):
     # Create actions to generate the three output files.
     # Actions are run only when the corresponding file is requested.

--- a/rules/predeclared_outputs/hash.bzl
+++ b/rules/predeclared_outputs/hash.bzl
@@ -1,19 +1,21 @@
-# A rule that takes in a series of "declarations" and produces "compiled
-# output" for some of those declarations, along with a manifest. Here, the
-# declarations are simply words in a dictionary text file, and the compiled
-# output of a word is just its hash.
-#
-# The compiled outputs are specified by the user, while the manifest file is
-# created automatically. Both kinds of outputs are predeclared, and can be
-# referred to in the target graph or built in the command line, e.g.:
-#
-#     bazel build //predeclared_outputs:dog.md5
-#
-# If you do not need to refer to the output files as labels, it may be simpler
-# to pass in the words as an attr.string_list, and declare the files in the
-# implementation function instead.
-#
-# This rule assumes the presence of shell commands "grep", "md5sum", and "cut".
+"""
+A rule that takes in a series of "declarations" and produces "compiled
+output" for some of those declarations, along with a manifest. Here, the
+declarations are simply words in a dictionary text file, and the compiled
+output of a word is just its hash.
+
+The compiled outputs are specified by the user, while the manifest file is
+created automatically. Both kinds of outputs are predeclared, and can be
+referred to in the target graph or built in the command line, e.g.:
+
+    bazel build //predeclared_outputs:dog.md5
+
+If you do not need to refer to the output files as labels, it may be simpler
+to pass in the words as an attr.string_list, and declare the files in the
+implementation function instead.
+
+This rule assumes the presence of shell commands "grep", "md5sum", and "cut".
+"""
 
 def _word_hashes_impl(ctx):
     dictionary = ctx.file.dictionary


### PR DESCRIPTION
Suppress existing warnings on files, since I don't know what the docstrings should have been.