### PR TITLE
Fix path to next binary in Next.js example

### DIFF
--- a/frontend/next.js/BUILD.bazel
+++ b/frontend/next.js/BUILD.bazel
@@ -35,7 +35,7 @@ next(
         ":node_modules/react-dom",
         ":node_modules/typescript",
     ],
-    next_bin = "../../node_modules/.bin/next",
+    next_bin = "./node_modules/next/dist/bin/next",
     next_js_binary = ":next_js_binary",
 )
 


### PR DESCRIPTION
This fixes an omission during migration to this repository.

Fixes #323 