### PR TITLE
chore: add container runtime to Java example 

### DIFF
--- a/.bazelci/misc.yml
+++ b/.bazelci/misc.yml
@@ -16,14 +16,19 @@ tasks:
     - "..."
     test_targets:
     - "..."
+    test_flags:
+    # FIXME: either have a docker/podman runtime on our Mac images,
+    # or use a remote container service like TestContainers Cloud
+    - "--test_tag_filters=-requires-docker"
   java-maven-windows:
     name: "Maven Java App"
     platform: windows
     working_directory: ../java-maven
-    build_targets:
-    - "..."
     test_targets:
-    - "..."
+    # FIXME: Our Windows CI machines need some DLL and/or Visual C++ redistributable.
+    # running bsdtar.exe results in `Exit -1073741515: STATUS_DLL_NOT_FOUND`
+    # for now, only run the java_test target.
+    - "//:tests"
   third-party-dependencies-linux:
     name: "Example with third party dependencies"
     platform: ubuntu1804

--- a/.bazelci/misc.yml
+++ b/.bazelci/misc.yml
@@ -2,7 +2,7 @@
 tasks:
   java-maven-linux:
     name: "Maven Java App"
-    platform: ubuntu1804
+    platform: ubuntu2004
     working_directory: ../java-maven
     build_targets:
     - "..."

--- a/java-maven/BUILD
+++ b/java-maven/BUILD
@@ -48,4 +48,5 @@ container_structure_test(
     name = "container_test",
     configs = ["container-structure-test.yaml"],
     image = ":image",
+    tags = ["requires-docker"],
 )

--- a/java-maven/BUILD
+++ b/java-maven/BUILD
@@ -1,4 +1,7 @@
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -23,4 +26,26 @@ java_test(
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",
     ],
+)
+
+tar(
+    name = "layer",
+    srcs = ["java-maven_deploy.jar"],
+)
+
+oci_image(
+    name = "image",
+    base = "@distroless_java",
+    entrypoint = [
+        "java",
+        "-jar",
+        "/java-maven-deploy.jar",
+    ],
+    tars = [":layer"],
+)
+
+container_structure_test(
+    name = "container_test",
+    configs = ["container-structure-test.yaml"],
+    image = ":image",
 )

--- a/java-maven/MODULE.bazel
+++ b/java-maven/MODULE.bazel
@@ -1,9 +1,9 @@
 "Bazel dependencies"
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.0.0-beta1")
+bazel_dep(name = "aspect_bazel_lib", version = "2.0.0-rc0")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
-bazel_dep(name = "rules_oci", version = "1.2.0")
+bazel_dep(name = "rules_oci", version = "1.4.0")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(

--- a/java-maven/MODULE.bazel
+++ b/java-maven/MODULE.bazel
@@ -1,6 +1,9 @@
 "Bazel dependencies"
 
+bazel_dep(name = "aspect_bazel_lib", version = "2.0.0-beta1")
+bazel_dep(name = "container_structure_test", version = "1.16.0")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
+bazel_dep(name = "rules_oci", version = "1.2.0")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
@@ -15,3 +18,11 @@ maven.install(
     ],
 )
 use_repo(maven, "maven")
+
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+oci.pull(
+    name = "distroless_java",
+    digest = "sha256:161a1d97d592b3f1919801578c3a47c8e932071168a96267698f4b669c24c76d",
+    image = "gcr.io/distroless/java17",
+)
+use_repo(oci, "distroless_java")

--- a/java-maven/README.md
+++ b/java-maven/README.md
@@ -2,7 +2,7 @@ Maven Java application
 ----------------------
 
 This project demonstrates the usage of Bazel to retrieve dependencies from Maven
-repositories.
+repositories, build a program, and place it in an OCI container.
 
 To build this example, you will need to [install
 Bazel](http://bazel.io/docs/install.html).
@@ -25,4 +25,16 @@ Test the application by running:
 
 ```
 $ bazel test :tests
+```
+
+Create a container image, suitable to push to a remote docker registry:
+
+```
+$ bazel build :image
+```
+
+Test that the image works when running inside a container runtime:
+
+```
+$ bazel test :container_test
 ```

--- a/java-maven/container-structure-test.yaml
+++ b/java-maven/container-structure-test.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/GoogleContainerTools/container-structure-test#command-tests
+schemaVersion: 2.0.0
+commandTests:
+  - name: test
+    command: java
+    args: ['-jar', '/java-maven_deploy.jar']
+    expectedOutput: ['Success: 1']


### PR DESCRIPTION
Examples of using Docker (or alternative container runtimes) are probably best layered next to existing applications, since it's not a language-specific ruleset.