### PR TITLE
fix(frontend/react): pin `web-vitals` to 2.1.4

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
       react-scripts: 5.0.1
       tsconfig-to-swcconfig: 2.4.0
       typescript: 4.9.3
-      web-vitals: 3.1.0
+      web-vitals: 2.1.4
     dependencies:
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
@@ -87,7 +87,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-scripts: 5.0.1_eetduzquwu67aqoq5644t6dxzu
-      web-vitals: 3.1.0
+      web-vitals: 2.1.4
     devDependencies:
       '@bazel/ibazel': 0.16.2
       '@types/jest': 29.2.3
@@ -12313,8 +12313,8 @@ packages:
       minimalistic-assert: 1.0.1
     dev: false
 
-  /web-vitals/3.1.0:
-    resolution: {integrity: sha512-zCeQ+bOjWjJbXv5ZL0r8Py3XP2doCQMZXNKlBGfUjPAVZWokApdeF/kFlK1peuKlCt8sL9TFkKzyXE9/cmNJQA==}
+  /web-vitals/2.1.4:
+    resolution: {integrity: sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==}
     dev: false
 
   /webidl-conversions/4.0.2:

--- a/frontend/react/package.json
+++ b/frontend/react/package.json
@@ -9,7 +9,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "3.1.0"
+    "web-vitals": "2.1.4"
   },
   "devDependencies": {
     "@bazel/ibazel": "0.16.2",


### PR DESCRIPTION
This is a depracated version of `web-vitals`.

The v3 doesn't have the used functions anymore.

It would be better to port this code to use v3, but this at least allows users to bootstrap.