### PR TITLE
feat: demonstrate rules_lint for frontend monorepo

### DIFF
--- a/frontend/.bazelrc
+++ b/frontend/.bazelrc
@@ -11,8 +11,11 @@ build --enable_runfiles
 ###########################
 # Linting
 # Enable with --config=lint
-build:lint --aspects=//next.js:lint.bzl%eslint
-# Gather lint reports
+# This is demonstrated by the next.js example:
+# cd next.js; npm run lint
+build:lint --aspects=//:lint.bzl%eslint
+# Gather lint reports.
+# Note: --remote_download_regex is for RBE and was added in Bazel 7.
 build:lint --output_groups=rules_lint_report --remote_download_regex='.*aspect_rules_lint.report'
 # Cause build failures when there are lint warnings.
 # This is a simple configuration, but you probably want to report them as code review comments instead.

--- a/frontend/BUILD.bazel
+++ b/frontend/BUILD.bazel
@@ -1,7 +1,12 @@
 "Root BUILD file for all frontend examples"
 
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
+
+package(default_visibility = ["//:__subpackages__"])
 
 # Create the root of the "virtual store" of npm dependencies under bazel-out.
 # This must be done in the package where the pnpm workspace is rooted.
 npm_link_all_packages(name = "node_modules")
+
+eslint_bin.eslint_binary(name = "eslint")

--- a/frontend/MODULE.bazel
+++ b/frontend/MODULE.bazel
@@ -10,6 +10,12 @@ bazel_dep(name = "aspect_rules_rollup", version = "1.0.0")
 bazel_dep(name = "aspect_rules_webpack", version = "0.13.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 
+git_override(
+    module_name = "aspect_rules_lint",
+    commit = "270a3ea55ba4ee75f8fe15636c053c1cc7941e41",
+    remote = "https://github.com/aspect-build/rules_lint",
+)
+
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 use_repo(pnpm, "pnpm")
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,4 +5,11 @@ This folder contains various examples for writing JavaScript applications with B
 Bazel's [rules_js] uses the pnpm package manager. This folder is the root of a pnpm workspace.
 This allows npm packages within this monorepo to depend on each other.
 
+## Linting
+
+We demonstrate the usage of [rules_lint]. There are a few ways to wire this up, we show two:
+- in the `next.js/` folder, `npm run lint` does a `bazel build` with a config setting that makes the build fail when lint violations are found.
+- in the `react` folder, an `eslint_test` target results in test failures when lint violations are found.
+
 [rules_js]: https://docs.aspect.build/rules/aspect_rules_js
+[rules_lint]: https://github.com/aspect-build/rules_lint

--- a/frontend/lint.bzl
+++ b/frontend/lint.bzl
@@ -4,8 +4,11 @@ load("@aspect_rules_lint//lint:eslint.bzl", "eslint_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "make_lint_test")
 
 eslint = eslint_aspect(
-    binary = "@@//next.js:eslint",
-    config = "@@//next.js:eslintrc",
+    binary = "@@//:eslint",
+    configs = [
+        "@@//react:package_json",
+        "@@//next.js:eslintrc",
+    ],
 )
 
 eslint_test = make_lint_test(aspect = eslint)

--- a/frontend/next.js/BUILD.bazel
+++ b/frontend/next.js/BUILD.bazel
@@ -2,7 +2,6 @@ load("@aspect_rules_js//js:defs.bzl", "js_library", "js_test")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//next.js:eslint/package_json.bzl", eslint_bin = "bin")
 load("@npm//next.js:next/package_json.bzl", next_bin = "bin")
 load("//next.js:defs.bzl", "next")
 
@@ -61,15 +60,10 @@ js_library(
     deps = [":node_modules/next"],
 )
 
-eslint_bin.eslint_binary(
-    name = "eslint",
-    visibility = ["//next.js:__subpackages__"],
-)
-
 js_library(
     name = "eslintrc",
     srcs = [".eslintrc.js"],
-    visibility = ["//next.js:__subpackages__"],
+    visibility = ["//:__subpackages__"],
     deps = [
         ":node_modules/@next/eslint-plugin-next",
         ":node_modules/eslint-config-next",

--- a/frontend/next.js/package.json
+++ b/frontend/next.js/package.json
@@ -6,7 +6,7 @@
     "build": "bazel build next",
     "export": "bazel build next_export",
     "start": "ibazel run next_start",
-    "lint": "bazel build --config=lint //next.js/pages:all",
+    "lint": "bazel build --config=lint //next.js/pages/...",
     "test": "bazel test ... --test_lang_filters=jest --build_tests_only"
   },
   "dependencies": {

--- a/frontend/next.js/pages/api/BUILD.bazel
+++ b/frontend/next.js/pages/api/BUILD.bazel
@@ -1,34 +1,12 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-load("@npm//next.js:eslint/package_json.bzl", eslint_bin = "bin")
-
-SRCS = [
-    "hello.ts",
-]
 
 ts_project(
     name = "api",
-    srcs = SRCS,
+    srcs = ["hello.ts"],
     declaration = True,
     resolve_json_module = True,
     transpiler = "tsc",
     tsconfig = "//next.js:tsconfig",
     visibility = ["//next.js/pages:__subpackages__"],
     deps = ["//next.js:node_modules/next"],
-)
-
-eslint_bin.eslint_test(
-    name = "eslint_test",
-    args = [
-        "--config $(location //next.js:eslintrc)",
-    ] + ["{}/{}".format(
-        package_name(),
-        s,
-    ) for s in SRCS],
-    data = SRCS + [
-        "//next.js:eslintrc",
-        "//next.js:node_modules/@next/eslint-plugin-next",
-        "//next.js:node_modules/eslint-config-next",
-        "//next.js:node_modules/next",
-    ],
-    tags = ["lint"],
 )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,9 @@
 {
     "// To install dependencies with Bazel-managed pnpm, run": "bazel run @pnpm//:pnpm -- --dir $PWD install",
     "private": true,
+    "devDependencies": {
+      "eslint": "^8.55.0"
+    },
     "pnpm": {
       "//packageExtensions": "Fix missing dependencies in npm packages, see https://pnpm.io/package_json#pnpmpackageextensions",
       "packageExtensions": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,7 +8,11 @@ packageExtensionsChecksum: 1137c84cb3f5d653debe824f83a85f54
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      eslint:
+        specifier: ^8.55.0
+        version: 8.55.0
 
   next.js:
     dependencies:
@@ -103,7 +107,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.28.0)(react@18.2.0)(typescript@4.9.3)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.55.0)(react@18.2.0)(typescript@4.9.3)
       web-vitals:
         specifier: 2.1.4
         version: 2.1.4
@@ -116,10 +120,10 @@ importers:
         version: 29.2.3
       '@typescript-eslint/eslint-plugin':
         specifier: 5.44.0
-        version: 5.44.0(@typescript-eslint/parser@5.44.0)(eslint@8.28.0)(typescript@4.9.3)
+        version: 5.44.0(@typescript-eslint/parser@5.44.0)(eslint@8.55.0)(typescript@4.9.3)
       '@typescript-eslint/parser':
         specifier: 5.44.0
-        version: 5.44.0(eslint@8.28.0)(typescript@4.9.3)
+        version: 5.44.0(eslint@8.55.0)(typescript@4.9.3)
       jest-cli:
         specifier: 29.5.0
         version: 29.5.0(@types/node@18.11.9)
@@ -287,7 +291,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/eslint-parser@7.22.15(@babel/core@7.23.0)(eslint@8.28.0):
+  /@babel/eslint-parser@7.22.15(@babel/core@7.23.0)(eslint@8.55.0):
     resolution: {integrity: sha512-yc8OOBIQk1EcRrpizuARSQS0TWAcOMpEJ1aafhNznaeYkeL+OhqnDObGFylB8ka8VFF/sZc+S4RzHyO+3LjQxg==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -296,7 +300,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.28.0
+      eslint: 8.55.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
     dev: false
@@ -1829,15 +1833,18 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.28.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.55.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.28.0
+      eslint: 8.55.0
       eslint-visitor-keys: 3.4.3
-    dev: false
+
+  /@eslint-community/regexpp@4.10.0:
+    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   /@eslint/eslintrc@1.4.1:
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
@@ -1854,6 +1861,27 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@eslint/eslintrc@2.1.4:
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4
+      espree: 9.6.1
+      globals: 13.22.0
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  /@eslint/js@8.55.0:
+    resolution: {integrity: sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /@fastify/deepmerge@1.3.0:
     resolution: {integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==}
@@ -1868,6 +1896,17 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@humanwhocodes/config-array@0.11.13:
+    resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.1
+      debug: 4.3.4
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1875,6 +1914,10 @@ packages:
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
+
+  /@humanwhocodes/object-schema@2.0.1:
+    resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
 
   /@istanbuljs/load-nyc-config@1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -3215,7 +3258,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.1
 
-  /@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0)(eslint@8.28.0)(typescript@4.9.3):
+  /@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0)(eslint@8.55.0)(typescript@4.9.3):
     resolution: {integrity: sha512-j5ULd7FmmekcyWeArx+i8x7sdRHzAtXTkmDPthE4amxZOWKFK7bomoJ4r7PJ8K7PoMzD16U8MmuZFAonr1ERvw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3226,12 +3269,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@4.9.3)
+      '@typescript-eslint/parser': 5.44.0(eslint@8.55.0)(typescript@4.9.3)
       '@typescript-eslint/scope-manager': 5.44.0
-      '@typescript-eslint/type-utils': 5.44.0(eslint@8.28.0)(typescript@4.9.3)
-      '@typescript-eslint/utils': 5.44.0(eslint@8.28.0)(typescript@4.9.3)
+      '@typescript-eslint/type-utils': 5.44.0(eslint@8.55.0)(typescript@4.9.3)
+      '@typescript-eslint/utils': 5.44.0(eslint@8.55.0)(typescript@4.9.3)
       debug: 4.3.4
-      eslint: 8.28.0
+      eslint: 8.55.0
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
@@ -3241,14 +3284,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/experimental-utils@5.62.0(eslint@8.28.0)(typescript@4.9.3):
+  /@typescript-eslint/experimental-utils@5.62.0(eslint@8.55.0)(typescript@4.9.3):
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.28.0)(typescript@4.9.3)
-      eslint: 8.28.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.55.0)(typescript@4.9.3)
+      eslint: 8.55.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3272,6 +3315,26 @@ packages:
       typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@5.44.0(eslint@8.55.0)(typescript@4.9.3):
+    resolution: {integrity: sha512-H7LCqbZnKqkkgQHaKLGC6KUjt3pjJDx8ETDqmwncyb6PuoigYajyAwBGz08VU/l86dZWZgI4zm5k2VaKqayYyA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.44.0
+      '@typescript-eslint/types': 5.44.0
+      '@typescript-eslint/typescript-estree': 5.44.0(typescript@4.9.3)
+      debug: 4.3.4
+      eslint: 8.55.0
+      typescript: 4.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   /@typescript-eslint/scope-manager@5.44.0:
     resolution: {integrity: sha512-2pKml57KusI0LAhgLKae9kwWeITZ7IsZs77YxyNyIVOwQ1kToyXRaJLl+uDEXzMN5hnobKUOo2gKntK9H1YL8g==}
@@ -3288,7 +3351,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
-  /@typescript-eslint/type-utils@5.44.0(eslint@8.28.0)(typescript@4.9.3):
+  /@typescript-eslint/type-utils@5.44.0(eslint@8.55.0)(typescript@4.9.3):
     resolution: {integrity: sha512-A1u0Yo5wZxkXPQ7/noGkRhV4J9opcymcr31XQtOzcc5nO/IHN2E2TPMECKWYpM3e6olWEM63fq/BaL1wEYnt/w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3299,9 +3362,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.44.0(typescript@4.9.3)
-      '@typescript-eslint/utils': 5.44.0(eslint@8.28.0)(typescript@4.9.3)
+      '@typescript-eslint/utils': 5.44.0(eslint@8.55.0)(typescript@4.9.3)
       debug: 4.3.4
-      eslint: 8.28.0
+      eslint: 8.55.0
       tsutils: 3.21.0(typescript@4.9.3)
       typescript: 4.9.3
     transitivePeerDependencies:
@@ -3357,7 +3420,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.44.0(eslint@8.28.0)(typescript@4.9.3):
+  /@typescript-eslint/utils@5.44.0(eslint@8.55.0)(typescript@4.9.3):
     resolution: {integrity: sha512-fMzA8LLQ189gaBjS0MZszw5HBdZgVwxVFShCO3QN+ws3GlPkcy9YuS3U4wkT6su0w+Byjq3mS3uamy9HE4Yfjw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3368,27 +3431,27 @@ packages:
       '@typescript-eslint/scope-manager': 5.44.0
       '@typescript-eslint/types': 5.44.0
       '@typescript-eslint/typescript-estree': 5.44.0(typescript@4.9.3)
-      eslint: 8.28.0
+      eslint: 8.55.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.28.0)
+      eslint-utils: 3.0.0(eslint@8.55.0)
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.28.0)(typescript@4.9.3):
+  /@typescript-eslint/utils@5.62.0(eslint@8.55.0)(typescript@4.9.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.28.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.55.0)
       '@types/json-schema': 7.0.13
       '@types/semver': 7.5.3
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.3)
-      eslint: 8.28.0
+      eslint: 8.55.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -3410,6 +3473,9 @@ packages:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
     dev: false
+
+  /@ungap/structured-clone@1.2.0:
+    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
   /@vitejs/plugin-vue-jsx@2.1.1(vite@3.2.7)(vue@3.2.45):
     resolution: {integrity: sha512-JgDhxstQlwnHBvZ1BSnU5mbmyQ14/t5JhREc6YH5kWyu2QdAAOsLF6xgHoIWarj8tddaiwFrNzLbWJPudpXKYA==}
@@ -5862,7 +5928,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.28.0)(jest@27.5.1)(typescript@4.9.3):
+  /eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.55.0)(jest@27.5.1)(typescript@4.9.3):
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -5873,20 +5939,20 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/eslint-parser': 7.22.15(@babel/core@7.23.0)(eslint@8.28.0)
+      '@babel/eslint-parser': 7.22.15(@babel/core@7.23.0)(eslint@8.55.0)
       '@rushstack/eslint-patch': 1.5.1
-      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0)(eslint@8.28.0)(typescript@4.9.3)
-      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@4.9.3)
+      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0)(eslint@8.55.0)(typescript@4.9.3)
+      '@typescript-eslint/parser': 5.44.0(eslint@8.55.0)(typescript@4.9.3)
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 8.28.0
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.28.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.44.0)(eslint@8.28.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.44.0)(eslint@8.28.0)(jest@27.5.1)(typescript@4.9.3)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.28.0)
-      eslint-plugin-react: 7.33.2(eslint@8.28.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.28.0)
-      eslint-plugin-testing-library: 5.11.1(eslint@8.28.0)(typescript@4.9.3)
+      eslint: 8.55.0
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.55.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.44.0)(eslint@8.55.0)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.44.0)(eslint@8.55.0)(jest@27.5.1)(typescript@4.9.3)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.55.0)
+      eslint-plugin-react: 7.33.2(eslint@8.55.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.55.0)
+      eslint-plugin-testing-library: 5.11.1(eslint@8.55.0)(typescript@4.9.3)
       typescript: 4.9.3
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
@@ -5927,6 +5993,7 @@ packages:
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
 
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.44.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -5956,8 +6023,38 @@ packages:
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.28.0)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
-  /eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.28.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.44.0)(eslint-import-resolver-node@0.3.9)(eslint@8.55.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.44.0(eslint@8.55.0)(typescript@4.9.3)
+      debug: 3.2.7
+      eslint: 8.55.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.55.0):
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -5967,7 +6064,7 @@ packages:
     dependencies:
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.23.0)
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.0)
-      eslint: 8.28.0
+      eslint: 8.55.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
     dev: false
@@ -6005,8 +6102,9 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
 
-  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@5.44.0)(eslint@8.28.0):
+  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@5.44.0)(eslint@8.55.0):
     resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -6016,16 +6114,16 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@4.9.3)
+      '@typescript-eslint/parser': 5.44.0(eslint@8.55.0)(typescript@4.9.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.28.0
+      eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.44.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.44.0)(eslint-import-resolver-node@0.3.9)(eslint@8.55.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -6041,7 +6139,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.44.0)(eslint@8.28.0)(jest@27.5.1)(typescript@4.9.3):
+  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.44.0)(eslint@8.55.0)(jest@27.5.1)(typescript@4.9.3):
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -6054,9 +6152,9 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0)(eslint@8.28.0)(typescript@4.9.3)
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.28.0)(typescript@4.9.3)
-      eslint: 8.28.0
+      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0)(eslint@8.55.0)(typescript@4.9.3)
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.55.0)(typescript@4.9.3)
+      eslint: 8.55.0
       jest: 27.5.1
     transitivePeerDependencies:
       - supports-color
@@ -6086,6 +6184,32 @@ packages:
       object.entries: 1.1.7
       object.fromentries: 2.0.7
       semver: 6.3.1
+    dev: true
+
+  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.55.0):
+    resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      '@babel/runtime': 7.23.1
+      aria-query: 5.3.0
+      array-includes: 3.1.7
+      array.prototype.flatmap: 1.3.2
+      ast-types-flow: 0.0.7
+      axe-core: 4.8.2
+      axobject-query: 3.2.1
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 8.55.0
+      has: 1.0.3
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.5
+      minimatch: 3.1.2
+      object.entries: 1.1.7
+      object.fromentries: 2.0.7
+      semver: 6.3.1
+    dev: false
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.28.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
@@ -6094,6 +6218,16 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.28.0
+    dev: true
+
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.55.0):
+    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.55.0
+    dev: false
 
   /eslint-plugin-react@7.33.2(eslint@8.28.0):
     resolution: {integrity: sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==}
@@ -6118,15 +6252,41 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
+    dev: true
 
-  /eslint-plugin-testing-library@5.11.1(eslint@8.28.0)(typescript@4.9.3):
+  /eslint-plugin-react@7.33.2(eslint@8.55.0):
+    resolution: {integrity: sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      array-includes: 3.1.7
+      array.prototype.flatmap: 1.3.2
+      array.prototype.tosorted: 1.1.2
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.0.15
+      eslint: 8.55.0
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.7
+      object.fromentries: 2.0.7
+      object.hasown: 1.1.3
+      object.values: 1.1.7
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.4
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.10
+    dev: false
+
+  /eslint-plugin-testing-library@5.11.1(eslint@8.55.0)(typescript@4.9.3):
     resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.28.0)(typescript@4.9.3)
-      eslint: 8.28.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.55.0)(typescript@4.9.3)
+      eslint: 8.55.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6154,6 +6314,16 @@ packages:
     dependencies:
       eslint: 8.28.0
       eslint-visitor-keys: 2.1.0
+    dev: true
+
+  /eslint-utils@3.0.0(eslint@8.55.0):
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint: 8.55.0
+      eslint-visitor-keys: 2.1.0
 
   /eslint-visitor-keys@2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
@@ -6163,7 +6333,7 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /eslint-webpack-plugin@3.2.0(eslint@8.28.0)(webpack@5.88.2):
+  /eslint-webpack-plugin@3.2.0(eslint@8.55.0)(webpack@5.88.2):
     resolution: {integrity: sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -6171,7 +6341,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       '@types/eslint': 8.44.3
-      eslint: 8.28.0
+      eslint: 8.55.0
       jest-worker: 28.1.3
       micromatch: 4.0.5
       normalize-path: 3.0.0
@@ -6222,6 +6392,53 @@ packages:
       regexpp: 3.2.0
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint@8.55.0:
+    resolution: {integrity: sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.55.0)
+      '@eslint-community/regexpp': 4.10.0
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.55.0
+      '@humanwhocodes/config-array': 0.11.13
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.2.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.22.0
+      graphemer: 1.4.0
+      ignore: 5.2.4
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      strip-ansi: 6.0.1
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
@@ -6512,7 +6729,7 @@ packages:
     dependencies:
       is-callable: 1.2.7
 
-  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.28.0)(typescript@4.9.3)(webpack@5.88.2):
+  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.55.0)(typescript@4.9.3)(webpack@5.88.2):
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -6532,7 +6749,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 8.28.0
+      eslint: 8.55.0
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.5.3
@@ -6660,6 +6877,7 @@ packages:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
     dependencies:
       resolve-pkg-maps: 1.0.0
+    dev: true
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -6761,6 +6979,10 @@ packages:
 
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+    dev: true
+
+  /graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   /gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
@@ -8454,6 +8676,7 @@ packages:
 
   /js-sdsl@4.4.2:
     resolution: {integrity: sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==}
+    dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -10353,7 +10576,7 @@ packages:
       whatwg-fetch: 3.6.19
     dev: false
 
-  /react-dev-utils@12.0.1(eslint@8.28.0)(typescript@4.9.3)(webpack@5.88.2):
+  /react-dev-utils@12.0.1(eslint@8.55.0)(typescript@4.9.3)(webpack@5.88.2):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -10372,7 +10595,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.28.0)(typescript@4.9.3)(webpack@5.88.2)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.55.0)(typescript@4.9.3)(webpack@5.88.2)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -10422,7 +10645,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react-scripts@5.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.28.0)(react@18.2.0)(typescript@4.9.3):
+  /react-scripts@5.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.55.0)(react@18.2.0)(typescript@4.9.3):
     resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -10449,9 +10672,9 @@ packages:
       css-minimizer-webpack-plugin: 3.4.1(webpack@5.88.2)
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 8.28.0
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.28.0)(jest@27.5.1)(typescript@4.9.3)
-      eslint-webpack-plugin: 3.2.0(eslint@8.28.0)(webpack@5.88.2)
+      eslint: 8.55.0
+      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.22.5)(@babel/plugin-transform-react-jsx@7.22.15)(eslint@8.55.0)(jest@27.5.1)(typescript@4.9.3)
+      eslint-webpack-plugin: 3.2.0(eslint@8.55.0)(webpack@5.88.2)
       file-loader: 6.2.0(webpack@5.88.2)
       fs-extra: 10.1.0
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
@@ -10468,7 +10691,7 @@ packages:
       prompts: 2.4.2
       react: 18.2.0
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.28.0)(typescript@4.9.3)(webpack@5.88.2)
+      react-dev-utils: 12.0.1(eslint@8.55.0)(typescript@4.9.3)(webpack@5.88.2)
       react-refresh: 0.11.0
       resolve: 1.22.6
       resolve-url-loader: 4.0.0
@@ -10696,6 +10919,7 @@ packages:
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
 
   /resolve-url-loader@4.0.0:
     resolution: {integrity: sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==}

--- a/frontend/react/BUILD.bazel
+++ b/frontend/react/BUILD.bazel
@@ -65,6 +65,7 @@ js_library(
     name = "package_json",
     srcs = ["package.json"],
     visibility = ["//visibility:public"],
+    deps = [":node_modules/eslint-config-react-app"],
 )
 
 js_library(

--- a/frontend/react/src/BUILD.bazel
+++ b/frontend/react/src/BUILD.bazel
@@ -3,7 +3,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_swc//swc:defs.bzl", "swc")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//lib:partial.bzl", "partial")
-load("@npm//react:eslint/package_json.bzl", eslint_bin = "bin")
+load("//:lint.bzl", "eslint_test")
 
 ASSET_PATTERNS = [
     "*.svg",
@@ -83,15 +83,10 @@ jest_test(
     node_modules = "//react:node_modules",
 )
 
-eslint_bin.eslint_test(
-    name = "eslint_test",
+# Test that fails if the lint report is non-empty
+# Remove the `eslint-disable-next-line` line from index.tsx to see this test fail.
+eslint_test(
+    name = "lint",
     timeout = "short",
-    args = ["{}/{}".format(
-        package_name(),
-        p,
-    ) for p in SRC_PATTERNS],
-    data = [
-        "//react:node_modules/eslint-config-react-app",
-        "//react:package_json",
-    ] + glob(SRC_PATTERNS),
+    srcs = [":src_ts_typings"],
 )

--- a/frontend/react/src/index.tsx
+++ b/frontend/react/src/index.tsx
@@ -14,4 +14,5 @@ root.render(
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+// eslint-disable-next-line no-new-func
 reportWebVitals(Function());


### PR DESCRIPTION
Install a single eslint binary in the root of the pnpm workspace. Note, the version might not match what next.js or CRA would create in the subpackage.
Pass all eslint configs to the eslint aspect, so that it can visit any library target in the repo. ESLint should select the right configuration for each file.
In react, demonstrate using eslint as a test target rather than a build failure.