### PR TITLE
Disable some android example testing in Bazel downstream

### DIFF
--- a/.bazelci/android.yml
+++ b/.bazelci/android.yml
@@ -22,6 +22,7 @@ common:
       - "--enable_bzlmod"
     build_targets:
       - "//app/src/main:app"
+    skip_in_bazel_downstream_pipeline: "Due to https://github.com/bazelbuild/examples/issues/381"
   android-jetpack: &android-jetpack
     name: "Android Jetpack Compose"
     # Cannot upgrade this until rules_kotlin is compatible.
@@ -33,6 +34,7 @@ common:
       - "--enable_bzlmod"
     build_targets:
       - "//app/src/main:app"
+    skip_in_bazel_downstream_pipeline: "Due to https://github.com/bazelbuild/examples/issues/381"      
   android-robolectric: &android-robolectric
     name: "Android Robolectric Testing"
     # Cannot upgrade this until rules_kotlin is compatible.
@@ -43,6 +45,7 @@ common:
       - "--enable_bzlmod"
     test_targets:
       - "//app:test"
+    skip_in_bazel_downstream_pipeline: "Due to https://github.com/bazelbuild/examples/issues/381"  
 
 tasks:
   android-firebase-linux:


### PR DESCRIPTION
Due to https://github.com/bazelbuild/examples/issues/381