### PR TITLE
chore(frontend): upgrade Node from v16 to v18

### DIFF
--- a/.bazelci/frontend.yml
+++ b/.bazelci/frontend.yml
@@ -11,7 +11,7 @@ rolling: &rolling
 # Commmon features by platform
 #
 linux: &linux
-  platform: ubuntu1804
+  platform: ubuntu2004
 
 macos: &macos
   platform: macos

--- a/frontend/MODULE.bazel
+++ b/frontend/MODULE.bazel
@@ -9,6 +9,10 @@ bazel_dep(name = "aspect_rules_ts", version = "2.2.0")
 bazel_dep(name = "aspect_rules_rollup", version = "1.0.2")
 bazel_dep(name = "aspect_rules_webpack", version = "0.14.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "rules_nodejs", version = "6.1.0")
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
+node.toolchain(node_version = "18.17.0")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm", dev_dependency = True)
 use_repo(pnpm, "pnpm")


### PR DESCRIPTION
This is required by some newer dependencies such as next.js v14