### PR TITLE
Update java-maven BUILD's jar path

### DIFF
--- a/java-maven/BUILD
+++ b/java-maven/BUILD
@@ -39,7 +39,7 @@ oci_image(
     entrypoint = [
         "java",
         "-jar",
-        "/java-maven-deploy.jar",
+        "/java-maven_deploy.jar",
     ],
     tars = [":layer"],
 )


### PR DESCRIPTION
[java_binary](https://bazel.build/reference/be/java#java_binary) creates a `<name>_deploy.jar` target, but the one used in example is `-deploy.jar` which doesn't exist.

If you run the current image it errors out:
```
Error: Unable to access jarfile /java-maven-deploy.jar
```

This PR updates the path to the correct one