### PR TITLE
fix typo in `make-variables/README.md`

### DIFF
--- a/make-variables/README.md
+++ b/make-variables/README.md
@@ -61,7 +61,7 @@ source file paths
 ```
 
 ## Custom Starlark-defined variables
-`//testapp:show_custom_var` demonstrates custom variable defined in Starlrak.
+`//testapp:show_custom_var` demonstrates custom variable defined in Starlark.
 ```
 $ bazel build //testapp:show_custom_var && cat bazel-bin/testapp/custom_var
 Target //testapp:show_custom_var up-to-date:


### PR DESCRIPTION
As the subject says.