### PR TITLE
Skipping Testcases of Bazel examples in downstream.

### DIFF
--- a/.bazelci/tutorial-rust.yml
+++ b/.bazelci/tutorial-rust.yml
@@ -12,12 +12,14 @@ tasks:
     working_directory: ../rust-examples/02-hello-cross
     build_targets:
       - "//:all"
+    skip_in_bazel_downstream_pipeline: "https://github.com/bazelbuild/examples/issues/540"
   rust-02-hello-cross-mac:
     name: "Rust Cross Compilation"
     platform: macos_arm64
     working_directory: ../rust-examples/02-hello-cross
     build_targets:
       - "//:all"
+    skip_in_bazel_downstream_pipeline: "https://github.com/bazelbuild/examples/issues/540"
   rust-03-comp-opt-linux:
     name: "Rust Compiler Optimization"
     platform: ubuntu2204
@@ -36,30 +38,35 @@ tasks:
     working_directory: ../rust-examples/05-deps-cargo
     build_targets:
       - "//..."
+    skip_in_bazel_downstream_pipeline: "https://github.com/bazelbuild/examples/issues/540"
   rust-06-deps-direct-linux:
     name: "Rust Direct Deps"
     platform: ubuntu2204
     working_directory: ../rust-examples/06-deps-direct
     build_targets:
       - "//..."
+    skip_in_bazel_downstream_pipeline: "https://github.com/bazelbuild/examples/issues/540"
   rust-07-deps-vendor-linux:
     name: "Rust Vendored Deps"
     platform: ubuntu2204
     working_directory: ../rust-examples/07-deps-vendor
     build_targets:
       - "//..."
+    skip_in_bazel_downstream_pipeline: "https://github.com/bazelbuild/examples/issues/540"
   rust-08-grpc-client-server-linux:
      name: "Rust grpc"
      platform: ubuntu2204
      working_directory: ../rust-examples/08-grpc-client-server
      build_targets:
        - "//..."
+     skip_in_bazel_downstream_pipeline: "https://github.com/bazelbuild/examples/issues/540"
   rust-08-grpc-client-server-macos:
     name: "Rust grpc"
     platform: macos_arm64
     working_directory: ../rust-examples/08-grpc-client-server
     build_targets:
       - "//..."
+    skip_in_bazel_downstream_pipeline: "https://github.com/bazelbuild/examples/issues/540"
   rust-09-oci-container-linux:
     name: "Rust OCI"
     platform: ubuntu2204
@@ -67,3 +74,4 @@ tasks:
     build_targets:
       - "//..."
       - "//tokio_oci:image"
+    skip_in_bazel_downstream_pipeline: "https://github.com/bazelbuild/examples/issues/540"


### PR DESCRIPTION
Reason : https://github.com/bazelbuild/examples/issues/540

CC @meteorcloudy 