### PR TITLE
Update aspect_lint to 1.2.2

### DIFF
--- a/frontend/MODULE.bazel
+++ b/frontend/MODULE.bazel
@@ -1,7 +1,7 @@
 "Bazel module dependencies, see https://bazel.build/external/overview#bzlmod"
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
-bazel_dep(name = "aspect_rules_lint", version = "1.0.0-rc4")
+bazel_dep(name = "aspect_rules_lint", version = "1.2.2")
 bazel_dep(name = "aspect_rules_jest", version = "0.22.0")
 bazel_dep(name = "aspect_rules_js", version = "2.0.2")
 bazel_dep(name = "aspect_rules_swc", version = "2.0.1")


### PR DESCRIPTION
Expected to fix issues with Bazel@HEAD now that the shell runfiles library has been moved out of Bazel.