### PR TITLE
Fixes incompatible_merge_fixed_and_default_shell_env flag error

### DIFF
--- a/rust-examples/01-hello-world/.bazelrc
+++ b/rust-examples/01-hello-world/.bazelrc
@@ -17,9 +17,6 @@ build:windows --enable_runfiles
 ## Build configuration
 ###############################################################################
 
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env
-
 # Enable C++ toolchain resolution.
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/rust-examples/02-hello-cross/.bazelrc
+++ b/rust-examples/02-hello-cross/.bazelrc
@@ -17,9 +17,6 @@ build:windows --enable_runfiles
 ## Build configuration
 ###############################################################################
 
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env
-
 # Enable C++ toolchain resolution.
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/rust-examples/03-comp-opt/.bazelrc
+++ b/rust-examples/03-comp-opt/.bazelrc
@@ -17,9 +17,6 @@ build:windows --enable_runfiles
 ## Build configuration
 ###############################################################################
 
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env
-
 # Enable C++ toolchain resolution.
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/rust-examples/04-ffi/.bazelrc
+++ b/rust-examples/04-ffi/.bazelrc
@@ -17,9 +17,6 @@ build:windows --enable_runfiles
 ## Build configuration
 ###############################################################################
 
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env
-
 # Enable C++ toolchain resolution.
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/rust-examples/05-deps-cargo/.bazelrc
+++ b/rust-examples/05-deps-cargo/.bazelrc
@@ -2,6 +2,3 @@
 common --enable_platform_specific_config
 startup --windows_enable_symlinks
 build:windows --enable_runfiles
-
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env

--- a/rust-examples/06-deps-direct/.bazelrc
+++ b/rust-examples/06-deps-direct/.bazelrc
@@ -17,9 +17,6 @@ build:windows --enable_runfiles
 ## Build configuration
 ###############################################################################
 
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env
-
 # Enable C++ toolchain resolution.
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/rust-examples/07-deps-vendor/.bazelrc
+++ b/rust-examples/07-deps-vendor/.bazelrc
@@ -17,9 +17,6 @@ build:windows --enable_runfiles
 ## Build configuration
 ###############################################################################
 
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env
-
 # Enable C++ toolchain resolution.
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/rust-examples/08-grpc-client-server/.bazelrc
+++ b/rust-examples/08-grpc-client-server/.bazelrc
@@ -17,9 +17,6 @@ build:windows --enable_runfiles
 ## Build configuration
 ###############################################################################
 
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env
-
 # Enable C++ toolchain resolution.
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/rust-examples/09-oci-container/.bazelrc
+++ b/rust-examples/09-oci-container/.bazelrc
@@ -17,9 +17,6 @@ build:windows --enable_runfiles
 ## Build configuration
 ###############################################################################
 
-# Required for cargo_build_script support before Bazel 7
-build --incompatible_merge_fixed_and_default_shell_env
-
 # Enable C++ toolchain resolution.
 build --incompatible_enable_cc_toolchain_resolution
 


### PR DESCRIPTION
Fixes  https://github.com/bazelbuild/examples/issues/570  incompatible_merge_fixed_and_default_shell_env flag error in the CI https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4558#0195d0a3-12ed-486b-9936-22af4dbc34ac for all the Bazel Rust Examples.

CC Greenteam @meteorcloudy @fweikert 