### PR TITLE
chore(renovate): skip cargo and npm updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,8 @@
         "group:monorepos",
         "workarounds:all"
     ],
+    "enabledManagers": [
+        "bazel", "bazel-module", "bazelisk", "github-actions"
+    ],
     "labels": ["dependencies"]
 }


### PR DESCRIPTION
These produce a lot of PRs that no one wants to spend time reviewing. Also consumes a significant CI load when a batch of these PRs is created.