### PR TITLE
Remove outdated _allowlist_function_transition attribute

### DIFF
--- a/configurations/WORKSPACE
+++ b/configurations/WORKSPACE
@@ -1,0 +1,1 @@
+# Marker that this folder is the root of a Bazel workspace.

--- a/configurations/WORKSPACE
+++ b/configurations/WORKSPACE
@@ -1,1 +1,0 @@
-# Marker that this folder is the root of a Bazel workspace.

--- a/configurations/attaching_transitions_to_rules/defs.bzl
+++ b/configurations/attaching_transitions_to_rules/defs.bzl
@@ -52,12 +52,6 @@ shirt = rule(
         # Use a private attribute (one that is prefixed with "_") so that target writers
         # can't override the value.
         "_color": attr.label(default = ":color"),
-        # This attribute is required to use starlark transitions. It allows
-        # allowlisting usage of this rule. For more information, see
-        # https://bazel.build/extending/config#user-defined-transitions
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
     },
 )
 

--- a/configurations/cc_binary_selectable_copts/defs.bzl
+++ b/configurations/cc_binary_selectable_copts/defs.bzl
@@ -56,17 +56,6 @@ transition_rule = rule(
         # Note specificaly how it's configured with _copt_transition, which
         # ensures that setting propagates down the graph.
         "actual_binary": attr.label(cfg = _copt_transition),
-        # This is a stock Bazel requirement for any rule that uses Starlark
-        # transitions. It's okay to copy the below verbatim for all such rules.
-        #
-        # The purpose of this requirement is to give the ability to restrict
-        # which packages can invoke these rules, since Starlark transitions
-        # make much larger graphs possible that can have memory and performance
-        # consequences for your build. The allowlist defaults to "everything".
-        # But you can redefine it more strictly if you feel that's prudent.
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
     },
     # Making this executable means it works with "$ bazel run".
     executable = True,

--- a/configurations/cc_test/README.md
+++ b/configurations/cc_test/README.md
@@ -1,4 +1,4 @@
-### Example showing how to use [Starlark configuration](https://bazel.build/extending/config) to write a`cc_test` wrapper with a starlark transition
+### Example showing how to use [Starlark configuration](https://bazel.build/extending/config) to write a `cc_test` wrapper with a starlark transition
 
 the `test_arg_cc_test` macro in `defs.bzl` defines a wrapper for basically a `cc_test` that has been transitioned.
 This allows, e.g., the test itself to select attribute values based on the value of that transition. There is some

--- a/configurations/cc_test/README.md
+++ b/configurations/cc_test/README.md
@@ -1,5 +1,4 @@
-### Example showing how to use [Starlark configuration](https://bazel.build/extending/config) to write a
-`cc_test` wrapper with a starlark transition
+### Example showing how to use [Starlark configuration](https://bazel.build/extending/config) to write a`cc_test` wrapper with a starlark transition
 
 the `test_arg_cc_test` macro in `defs.bzl` defines a wrapper for basically a `cc_test` that has been transitioned.
 This allows, e.g., the test itself to select attribute values based on the value of that transition. There is some

--- a/configurations/cc_test/defs.bzl
+++ b/configurations/cc_test/defs.bzl
@@ -32,9 +32,6 @@ transition_rule_test = rule(
     implementation = _test_transition_rule_impl,
     attrs = {
         "actual_test": attr.label(cfg = "target", executable = True),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
     },
     test = True,
 )

--- a/configurations/multi_arch_binary/defs.bzl
+++ b/configurations/multi_arch_binary/defs.bzl
@@ -38,12 +38,6 @@ foo_binary = rule(
     implementation = _rule_impl,
     attrs = {
         "tool": attr.label(cfg = fat_transition),
-        # This attribute is required to use Starlark transitions. It allows
-        # allowlisting usage of this rule. For more information, see
-        # https://bazel.build/extending/config#user-defined-transitions.
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
     },
 )
 

--- a/configurations/read_attr_in_transition/defs.bzl
+++ b/configurations/read_attr_in_transition/defs.bzl
@@ -28,8 +28,5 @@ my_rule = rule(
     attrs = {
         "do_transition": attr.bool(),
         "_some_string": attr.label(default = Label("//read_attr_in_transition:some-string")),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
     },
 )

--- a/configurations/transition_on_native_flag/defs.bzl
+++ b/configurations/transition_on_native_flag/defs.bzl
@@ -32,12 +32,6 @@ cpu_rule = rule(
     # the configuration of this target, which the target's descendents will inherit.
     cfg = cpu_transition,
     attrs = {
-        # This attribute is required to use starlark transitions. It allows
-        # allowlisting usage of this rule. For more information, see
-        # https://bazel.build/extending/config#user-defined-transitions
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
         "cpu": attr.string(default = "x86"),
     },
 )


### PR DESCRIPTION
No longer required since https://github.com/bazelbuild/bazel/commit/bb7fb2d32f055f2a70a5ab394cf5aef29bc74b2e (Bazel 7.0.0).
