### PR TITLE
Update CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,11 +4,12 @@
 AUTHORS  @meteorcloudy
 android/ @ahumesky @jin
 bzlmod/ @wyverald
-cpp-tutorial @oquenchil
-frontend @alexeagle
-java-maven/ @jin
-java-tutorial/ @jin
-make-variables @bazelbuild/configurability
-flags-parsing-tutorial @bazelbuild/configurability
-rules/starlark-configurations @bazelbuild/configurability
-third-party-dependencies @meteorcloudy
+configurations/ @bazelbuild/configurability
+cpp-tutorial/ @oquenchil
+flags-parsing-tutorial/ @bazelbuild/configurability
+frontend/ @alexeagle
+go-tutorial/ @bazelbuild/go-maintainers
+macros/ @brandjon
+make-variables/ @bazelbuild/configurability
+rules/ @comius
+third-party-dependencies/ @meteorcloudy


### PR DESCRIPTION
- Fix incorrect directories.
- Update to best-guess correct owners, preferring team labels when they exist.
- Exclude directories with one-off contributions: it's fine to keep default repo  ownership for these.