### PR TITLE
reproduce https://github.com/golang/go/issues/74080

### DIFF
--- a/go-tutorial/stage3/MODULE.bazel
+++ b/go-tutorial/stage3/MODULE.bazel
@@ -1,4 +1,7 @@
 bazel_dep(
     name = "rules_go",
-    version = "0.50.1",
+    version = "0.56.1",
 )
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.25rc2") # use 1.24.5 to avoid the error

--- a/go-tutorial/stage3/fortune/BUILD
+++ b/go-tutorial/stage3/fortune/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = ["fortune.go"],
     importpath = "github.com/bazelbuild/examples/go-tutorial/stage3/fortune",
     visibility = ["//visibility:public"],
+    cgo = True,
 )
 
 go_test(

--- a/go-tutorial/stage3/fortune/fortune.go
+++ b/go-tutorial/stage3/fortune/fortune.go
@@ -2,6 +2,8 @@ package fortune
 
 import "math/rand"
 
+import "C"
+
 var fortunes = []string{
 	"Your build will complete quickly.",
 	"Your dependencies will be free of bugs.",


### PR DESCRIPTION
Slightly modify the go bazel tutorial starter project to use go1.25rc2, the rules_go version (0.56.1) that supports go1.25, and modify one of the dependencies to be a CGO dependency in order to have rules_go trigger a the call to the "pack" command https://github.com/bazel-contrib/rules_go/blob/4957aa38634a54af69d1d02e510b0ec9df73619d/go/tools/builders/compilepkg.go#L459

cd to go-tutorial/stage3
bazel build ...

```
$ bazel build ...                                                                                                  ✘ 8
INFO: Invocation ID: 44cb2753-a615-42b9-b70b-de125ee25bc8
INFO: Analyzed 3 targets (55 packages loaded, 6231 targets configured).
ERROR: /home/user/gocode/src/github.com/bazelbuild/examples/go-tutorial/stage3/fortune/BUILD:3:11: GoCompilePkg fortune/fortune.a failed: (Exit 1): builder failed: error executing GoCompilePkg command (from target //fortune:fortune) bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/rules_go~~go_sdk~main___download_0/builder_reset/builder compilepkg -sdk external/rules_go~~go_sdk~main___download_0 -goroot ... (remaining 37 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
compilepkg: error running subcommand external/rules_go~~go_sdk~main___download_0/pkg/tool/linux_amd64/pack: fork/exec external/rules_go~~go_sdk~main___download_0/pkg/tool/linux_amd64/pack: no such file or directory
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 27.374s, Critical Path: 24.70s
INFO: 11 processes: 6 internal, 5 processwrapper-sandbox.
ERROR: Build did NOT complete successfully
```