### PR TITLE
Fix build with Bazel last_green

### DIFF
--- a/frontend/MODULE.bazel
+++ b/frontend/MODULE.bazel
@@ -2,7 +2,7 @@
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.0")
 bazel_dep(name = "aspect_rules_lint", version = "1.10.2")
-bazel_dep(name = "aspect_rules_jest", version = "0.22.0")
+bazel_dep(name = "aspect_rules_jest", version = "0.24.2")
 bazel_dep(name = "aspect_rules_js", version = "2.0.2")
 bazel_dep(name = "aspect_rules_swc", version = "2.4.4")
 bazel_dep(name = "aspect_rules_ts", version = "3.1.0")


### PR DESCRIPTION
Fixes: 
```
ERROR: /private/var/tmp/_bazel_fmeum/0465a0857e26a35c072f48ab751a1794/external/aspect_rules_jest+/jest/private/BUILD.bazel:11:1: name 'sh_binary' is not defined (did you mean 'cc_binary'?)
ERROR: /private/var/tmp/_bazel_fmeum/0465a0857e26a35c072f48ab751a1794/external/aspect_rules_jest+/jest/private/BUILD.bazel: no such target '@@aspect_rules_jest+//jest/private:jest_config_template.mjs': target 'jest_config_template.mjs' not declared in package 'jest/private' defined by /private/var/tmp/_bazel_fmeum/0465a0857e26a35c072f48ab751a1794/external/aspect_rules_jest+/jest/private/BUILD.bazel; however, a source file of this name exists.  (Perhaps add 'exports_files(["jest_config_template.mjs"])' to jest/private/BUILD.bazel?)
```