### PR TITLE
Bzlmod examples - Fix errors with glog for Bazel@HEAD

### DIFF
--- a/bzlmod/01-depend_on_bazel_module/BUILD
+++ b/bzlmod/01-depend_on_bazel_module/BUILD
@@ -3,5 +3,5 @@ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 cc_binary(
     name = "main",
     srcs = ["main.cc"],
-    deps = ["@com_github_google_glog//:glog"],
+    deps = ["@com_google_absl//absl/log"],
 )

--- a/bzlmod/01-depend_on_bazel_module/MODULE.bazel
+++ b/bzlmod/01-depend_on_bazel_module/MODULE.bazel
@@ -5,6 +5,6 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.17")
 
-# 1. The metadata of glog is fetched from the BCR, including its dependencies (gflags).
-# 2. The `repo_name` attribute allows users to reference this dependency via the `com_github_google_glog` repo name.
-bazel_dep(name = "glog", version = "0.5.0", repo_name = "com_github_google_glog")
+# 1. The metadata of abseil-cpp is fetched from the BCR, including its dependencies (platforms).
+# 2. The `repo_name` attribute allows users to reference this dependency via the `com_google_absl` repo name.
+bazel_dep(name = "abseil-cpp", version = "20250814.1", repo_name = "com_google_absl")

--- a/bzlmod/01-depend_on_bazel_module/main.cc
+++ b/bzlmod/01-depend_on_bazel_module/main.cc
@@ -1,9 +1,6 @@
-#include <glog/logging.h>
+#include "absl/log/log.h"
 
 int main(int argc, char* argv[]) {
-    // Initialize Google’s logging library.
-    google::InitGoogleLogging(argv[0]);
-
     int num_cookies = 42;
     LOG(INFO) << "Found " << num_cookies << " cookies";
 }

--- a/bzlmod/02-override_bazel_module/BUILD
+++ b/bzlmod/02-override_bazel_module/BUILD
@@ -8,7 +8,7 @@ cc_binary(
     name = "main",
     srcs = ["main.cc"],
     deps = [
-        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/log",
         "@lib_a",
     ],
 )

--- a/bzlmod/02-override_bazel_module/MODULE.bazel
+++ b/bzlmod/02-override_bazel_module/MODULE.bazel
@@ -3,32 +3,32 @@ module(
     version = "0.0.1",
 )
 
-bazel_dep(name = "rules_cc", version = "0.0.17")
-bazel_dep(name = "glog", version = "0.5.0", repo_name = "com_github_google_glog")
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "abseil-cpp", version = "20250814.1", repo_name = "com_google_absl")
 
-# Override glog to a fork version with archive_override.
+# # Override abseil-cpp to a fork version with archive_override.
 archive_override(
-    module_name = "glog",
-    integrity = "sha256-EH4o3n+qkfcsEFODkkRzs1/XAH9ej2V77gv05eplB5k=",
-    strip_prefix = "glog-9401faa19e0424791243827b8e95efd3d0d8db23",
-    urls = ["https://github.com/meteorcloudy/glog/archive/9401faa19e0424791243827b8e95efd3d0d8db23.tar.gz"],
+    module_name = "abseil-cpp",
+    integrity = "sha256-nfNEp86X1YI48kp7nyCFbubyFrtzDw+8dwBl0PACXrc=",
+    strip_prefix = "abseil-cpp-7599e36e7cbad38ec77cadd959d3a45d2124800a",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/7599e36e7cbad38ec77cadd959d3a45d2124800a.tar.gz"],
 )
 
-# Override gflag to a fork version with git_override.
-# gflag is still an indirect dependency, the override itself doesn't give the root module visibility on gflags.
+# Override platforms to a fork version with git_override.
+# platforms is still an indirect dependency, the override itself doesn't give the root module visibility on platforms.
 git_override(
-    module_name = "gflags",
-    commit = "95995169e86f3fedd19696df5b1811d441c462a2",
-    remote = "https://github.com/meteorcloudy/gflags.git",
+    module_name = "platforms",
+    commit = "5cf94563e35494b0dab15435868dd7f9e3cab2c8",
+    remote = "https://github.com/bazelbuild/platforms.git",
 )
 
-# Patch bazel skylib 1.7.1 with a local patch file.
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+# Patch bazel skylib 1.9.0 with a local patch file.
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 single_version_override(
     module_name = "bazel_skylib",
     patch_strip = 1,
     patches = ["//:bazel_skylib.patch"],
-    version = "1.7.1",
+    version = "1.9.0",
 )
 
 # Depend on module lib_a at a local path.

--- a/bzlmod/02-override_bazel_module/bazel_skylib.patch
+++ b/bzlmod/02-override_bazel_module/bazel_skylib.patch
@@ -5,5 +5,5 @@ index dc7f0ef..47768d8 100644
 @@ -14,3 +14,4 @@
  
  # Keep in sync with MODULE.bazel and @bazel_skylib_gazelle_plugin//:MODULE.bazel
- version = "1.7.1"
+ version = "1.9.0"
 +hello_msg = "Hello skylib"

--- a/bzlmod/02-override_bazel_module/lib_a/BUILD
+++ b/bzlmod/02-override_bazel_module/lib_a/BUILD
@@ -6,5 +6,5 @@ cc_library(
     name = "lib_a",
     srcs = ["lib_a.cc"],
     hdrs = ["lib_a.h"],
-    deps = ["@com_github_google_glog//:glog"],
+    deps = ["@com_google_absl//absl/log"],
 )

--- a/bzlmod/02-override_bazel_module/lib_a/MODULE.bazel
+++ b/bzlmod/02-override_bazel_module/lib_a/MODULE.bazel
@@ -4,4 +4,4 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.17")
-bazel_dep(name = "glog", version = "0.5.0", repo_name = "com_github_google_glog")
+bazel_dep(name = "abseil-cpp", version = "20250814.1", repo_name = "com_google_absl")

--- a/bzlmod/02-override_bazel_module/lib_a/lib_a.cc
+++ b/bzlmod/02-override_bazel_module/lib_a/lib_a.cc
@@ -1,4 +1,4 @@
-#include <glog/logging.h>
+#include "absl/log/log.h"
 
 void lib_a() {
     LOG(INFO) << "Hello from module A!";

--- a/bzlmod/02-override_bazel_module/main.cc
+++ b/bzlmod/02-override_bazel_module/main.cc
@@ -1,11 +1,8 @@
-#include <glog/logging.h>
+#include "absl/log/log.h"
 
 #include "lib_a.h"
 
 int main(int argc, char* argv[]) {
-    // Initialize Google’s logging library.
-    google::InitGoogleLogging(argv[0]);
-
     LOG(INFO) << "Hello from the main module!";
     lib_a();
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/examples/issues/644.

`Glog` repo needed patches in multiple places since it's missing load rules statements for Bazel@HEAD. Still, since glog is archived (https://github.com/google/glog), I've just switched to logging from absl.

