### PR TITLE
docs: Update iOS tutorial link to use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Some tutorials under <https://bazel.build/start> point to code in this repositor
 
 Note that tutorials for other languages may be found under other repositories:
 
- * [iOS tutorial](https://github.com/bazelbuild/rules_apple/blob/master/doc/tutorials/ios-app.md)
+ * [iOS tutorial](https://github.com/bazelbuild/rules_apple/blob/main/doc/tutorials/ios-app.md)
  * [Go tutorial](https://bazel.build/start/go) along with
    [sources](https://github.com/bazelbuild/rules_go/tree/master/examples/basic-gazelle)
 


### PR DESCRIPTION
rules_apple recently renamed from master to main 

https://github.com/bazelbuild/rules_apple/pull/2834