### PR TITLE
Add tsconfig paths example for next.js

### DIFF
--- a/frontend/next.js/components/BUILD.bazel
+++ b/frontend/next.js/components/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+SRCS = [
+    "button.tsx",
+]
+
+ts_project(
+    name = "components",
+    srcs = SRCS,
+    declaration = True,
+    resolve_json_module = True,
+    transpiler = "tsc",
+    tsconfig = "//next.js:tsconfig",
+    visibility = ["//next.js:__subpackages__"],
+    deps = [
+        "//next.js:node_modules/@types/react",
+        "//next.js:node_modules/@types/react-dom",
+        "//next.js:node_modules/next",
+    ],
+)

--- a/frontend/next.js/components/button.tsx
+++ b/frontend/next.js/components/button.tsx
@@ -1,0 +1,3 @@
+export default function Button() {
+  return <button>Click me</button>;
+}

--- a/frontend/next.js/pages/BUILD.bazel
+++ b/frontend/next.js/pages/BUILD.bazel
@@ -24,6 +24,7 @@ ts_project(
         "//next.js:node_modules/@types/react",
         "//next.js:node_modules/@types/react-dom",
         "//next.js:node_modules/next",
+        "//next.js/components",
         "//next.js/pages/api",
     ],
 )

--- a/frontend/next.js/pages/index.tsx
+++ b/frontend/next.js/pages/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import Image from 'next/image';
 import styles from '../styles/Home.module.css';
 import { one } from '@bazel-example/one';
+import Button from '@components/button';
 import isEven from 'is-even';
 
 // Uncomment this line to get a linting violation:
@@ -58,6 +59,8 @@ const Home: NextPage = () => {
               Instantly deploy your Next.js site to a public URL with Vercel.
             </p>
           </a>
+
+          <Button />
         </div>
       </main>
 

--- a/frontend/next.js/tsconfig.json
+++ b/frontend/next.js/tsconfig.json
@@ -11,7 +11,11 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["components/*"],
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Example to demonstrate the use of tsconfig paths.

* [rules_js docs](https://github.com/aspect-build/rules_js/blob/99ce5aa229a9900ca87e315e84614c40237a15cf/docs/faq.md?plain=1#L23-L26)
* [Example in rules_ts](https://github.com/aspect-build/rules_ts/blob/74d54bda208695d7e8992520e560166875cfbce7/examples/simple/tsconfig.json#L4-L10)
* [Next.js docs](https://nextjs.org/docs/14/app/building-your-application/configuring/absolute-imports-and-module-aliases)