### PR TITLE
[Downstream Bazel Fix] Temporarily patch rules_rust for Bazel@Head compatibility

### DIFF
--- a/rust-examples/05-deps-cargo/MODULE.bazel
+++ b/rust-examples/05-deps-cargo/MODULE.bazel
@@ -30,3 +30,11 @@ crate.from_cargo(
     manifests = ["//:Cargo.toml"],
 )
 use_repo(crate, "crates")
+
+# Temporarily needed for Bazel@Head until it's not fixed in rules_rust.
+# Update with new release once fixed: https://github.com/bazelbuild/rules_rust/issues/3962.
+archive_override(
+    module_name = "rules_rust",
+    patch_cmds = ["sed -i.bak 's/for key in dir(host_tools)/for key in [\"name\", \"version\", \"allocator_library\", \"dev_components\", \"edition\", \"rustfmt_version\", \"sha256s\", \"urls\"] if hasattr(host_tools, key)/' rust/extensions.bzl"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.65.0/rules_rust-0.65.0.tar.gz"],
+)

--- a/rust-examples/06-deps-direct/MODULE.bazel
+++ b/rust-examples/06-deps-direct/MODULE.bazel
@@ -58,3 +58,11 @@ crate.spec(
 )
 crate.from_specs()
 use_repo(crate, "crates")
+
+# Temporarily needed for Bazel@Head until it's not fixed in rules_rust.
+# Update with new release once fixed: https://github.com/bazelbuild/rules_rust/issues/3962.
+archive_override(
+    module_name = "rules_rust",
+    patch_cmds = ["sed -i.bak 's/for key in dir(host_tools)/for key in [\"name\", \"version\", \"allocator_library\", \"dev_components\", \"edition\", \"rustfmt_version\", \"sha256s\", \"urls\"] if hasattr(host_tools, key)/' rust/extensions.bzl"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.65.0/rules_rust-0.65.0.tar.gz"],
+)

--- a/rust-examples/07-deps-vendor/MODULE.bazel
+++ b/rust-examples/07-deps-vendor/MODULE.bazel
@@ -21,3 +21,11 @@ use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")
 
 # Rust dependencies; see thirdparty/BUILD.bazel
+
+# Temporarily needed for Bazel@Head until it's not fixed in rules_rust.
+# Update with new release once fixed: https://github.com/bazelbuild/rules_rust/issues/3962.
+archive_override(
+    module_name = "rules_rust",
+    patch_cmds = ["sed -i.bak 's/for key in dir(host_tools)/for key in [\"name\", \"version\", \"allocator_library\", \"dev_components\", \"edition\", \"rustfmt_version\", \"sha256s\", \"urls\"] if hasattr(host_tools, key)/' rust/extensions.bzl"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.65.0/rules_rust-0.65.0.tar.gz"],
+)

--- a/rust-examples/08-grpc-client-server/MODULE.bazel
+++ b/rust-examples/08-grpc-client-server/MODULE.bazel
@@ -115,3 +115,11 @@ crate.spec(
 )
 crate.from_specs()
 use_repo(crate, "crates")
+
+# Temporarily needed for Bazel@Head until it's not fixed in rules_rust.
+# Update with new release once fixed: https://github.com/bazelbuild/rules_rust/issues/3962.
+archive_override(
+    module_name = "rules_rust",
+    patch_cmds = ["sed -i.bak 's/for key in dir(host_tools)/for key in [\"name\", \"version\", \"allocator_library\", \"dev_components\", \"edition\", \"rustfmt_version\", \"sha256s\", \"urls\"] if hasattr(host_tools, key)/' rust/extensions.bzl"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.65.0/rules_rust-0.65.0.tar.gz"],
+)

--- a/rust-examples/09-oci-container/MODULE.bazel
+++ b/rust-examples/09-oci-container/MODULE.bazel
@@ -115,3 +115,11 @@ crate.spec(
 )
 crate.from_specs()
 use_repo(crate, "crates")
+
+# Temporarily needed for Bazel@Head until it's not fixed in rules_rust.
+# Update with new release once fixed: https://github.com/bazelbuild/rules_rust/issues/3962.
+archive_override(
+    module_name = "rules_rust",
+    patch_cmds = ["sed -i.bak 's/for key in dir(host_tools)/for key in [\"name\", \"version\", \"allocator_library\", \"dev_components\", \"edition\", \"rustfmt_version\", \"sha256s\", \"urls\"] if hasattr(host_tools, key)/' rust/extensions.bzl"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.65.0/rules_rust-0.65.0.tar.gz"],
+)


### PR DESCRIPTION
Fix https://github.com/bazelbuild/examples/issues/676.

Recent changes in Bazel 10's Starlark runtime (specifically `sort_key` metadata attached to TypeCheckedTag structures) caused `rules_rust` to unconditionally crash when unpacking Bzlmod tag keys via `dir()`:
``` 
 Error in repository_rule: unexpected Starlark value: <sort_key>
```

This fix is a temporary one, until it's fixed in rules_rust: https://github.com/bazelbuild/rules_rust/issues/3962.