### PR TITLE
Null-out Android env for non-Android macos builds

### DIFF
--- a/.bazelci/configurations.yml
+++ b/.bazelci/configurations.yml
@@ -24,6 +24,9 @@ windows: &windows
 #
 configurations: &configurations
   working_directory: ../configurations
+  environment:
+    ANDROID_HOME: ""
+    ANDROID_NDK_HOME: ""
   build_targets:
   - "..."
   # These targets demonstrate failures: they're never meant to build.

--- a/.bazelci/misc.yml
+++ b/.bazelci/misc.yml
@@ -11,6 +11,9 @@ tasks:
   java-maven-macos:
     name: "Maven Java App"
     platform: macos
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     working_directory: ../java-maven
     build_targets:
     - "..."

--- a/.bazelci/tutorial-cpp.yml
+++ b/.bazelci/tutorial-cpp.yml
@@ -9,6 +9,9 @@ tasks:
   cpp-stage1-macos:
     name: "C++ Stage 1"
     platform: macos
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     working_directory: ../cpp-tutorial/stage1
     build_targets:
       - "..."
@@ -27,6 +30,9 @@ tasks:
   cpp-stage2-macos:
     name: "C++ Stage 2"
     platform: macos
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     working_directory: ../cpp-tutorial/stage2
     build_targets:
       - "..."
@@ -45,6 +51,9 @@ tasks:
   cpp-stage3-macos:
     name: "C++ Stage 3"
     platform: macos
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     working_directory: ../cpp-tutorial/stage3
     build_targets:
       - "..."

--- a/.bazelci/tutorial-java.yml
+++ b/.bazelci/tutorial-java.yml
@@ -9,6 +9,9 @@ tasks:
   java-tutorial-macos:
     name: "Java Tutorial"
     platform: macos
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     working_directory: ../java-tutorial
     build_targets:
       - "//:ProjectRunner"
@@ -22,6 +25,9 @@ tasks:
   query-quickstart:
     name: "Query Quickstart"
     platform: macos
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     working_directory: ../query-quickstart
     build_targets:
       - "//:runner"


### PR DESCRIPTION
The Intel `macos` deployment does not have the latest Android build tools installed, so for these builds, we have to manually nullify the Android environment variables.