### PR TITLE
Remove the OCI parts of the java-maven example

### DIFF
--- a/.bazelci/misc.yml
+++ b/.bazelci/misc.yml
@@ -19,19 +19,15 @@ tasks:
     - "..."
     test_targets:
     - "..."
-    test_flags:
-    # FIXME: either have a docker/podman runtime on our Mac images,
-    # or use a remote container service like TestContainers Cloud
-    - "--test_tag_filters=-requires-docker"
   java-maven-windows:
     name: "Maven Java App"
     platform: windows
     working_directory: ../java-maven
+    build_targets:
+    - "..."
     test_targets:
-    # FIXME: Our Windows CI machines need some DLL and/or Visual C++ redistributable.
-    # running bsdtar.exe results in `Exit -1073741515: STATUS_DLL_NOT_FOUND`
-    # for now, only run the java_test target.
-    - "//:tests"
+    - "..."
+
   third-party-dependencies-linux:
     name: "Example with third party dependencies"
     platform: ubuntu2204

--- a/java-maven/BUILD
+++ b/java-maven/BUILD
@@ -1,7 +1,4 @@
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
-load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
-load("@rules_oci//oci:defs.bzl", "oci_image")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,27 +23,4 @@ java_test(
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",
     ],
-)
-
-tar(
-    name = "layer",
-    srcs = ["java-maven_deploy.jar"],
-)
-
-oci_image(
-    name = "image",
-    base = "@distroless_java",
-    entrypoint = [
-        "java",
-        "-jar",
-        "/java-maven-deploy.jar",
-    ],
-    tars = [":layer"],
-)
-
-container_structure_test(
-    name = "container_test",
-    configs = ["container-structure-test.yaml"],
-    image = ":image",
-    tags = ["requires-docker"],
 )

--- a/java-maven/MODULE.bazel
+++ b/java-maven/MODULE.bazel
@@ -1,9 +1,6 @@
 "Bazel dependencies"
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
-bazel_dep(name = "container_structure_test", version = "1.19.1")
 bazel_dep(name = "rules_jvm_external", version = "6.8")
-bazel_dep(name = "rules_oci", version = "2.2.6")
 bazel_dep(name = "rules_java", version = "7.11.1")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
@@ -19,11 +16,3 @@ maven.install(
     ],
 )
 use_repo(maven, "maven")
-
-oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
-oci.pull(
-    name = "distroless_java",
-    digest = "sha256:97891db4665b347af579b94f324f94f984a1e2e6d009b0015a1d2d214a0389d3",
-    image = "gcr.io/distroless/java17",
-)
-use_repo(oci, "distroless_java")

--- a/java-maven/README.md
+++ b/java-maven/README.md
@@ -2,7 +2,7 @@ Maven Java application
 ----------------------
 
 This project demonstrates the usage of Bazel to retrieve dependencies from Maven
-repositories, build a program, and place it in an OCI container.
+repositories and build a program.
 
 To build this example, you will need to [install
 Bazel](http://bazel.io/docs/install.html).
@@ -13,7 +13,7 @@ repository using Maven.
 
 This application demonstrates the usage of
 [`rules_jvm_external`](https://github.com/bazelbuild/rules_jvm_external/) to
-configure dependencies. The dependencies are configured in the `WORKSPACE` file.
+configure dependencies. The dependencies are configured in the `MODULE.bazel` file.
 
 Build the application by running:
 
@@ -25,16 +25,4 @@ Test the application by running:
 
 ```
 $ bazel test :tests
-```
-
-Create a container image, suitable to push to a remote docker registry:
-
-```
-$ bazel build :image
-```
-
-Test that the image works when running inside a container runtime:
-
-```
-$ bazel test :container_test
 ```

--- a/java-maven/container-structure-test.yaml
+++ b/java-maven/container-structure-test.yaml
@@ -1,7 +1,0 @@
-# See https://github.com/GoogleContainerTools/container-structure-test#command-tests
-schemaVersion: 2.0.0
-commandTests:
-  - name: test
-    command: java
-    args: ['-jar', '/java-maven_deploy.jar']
-    expectedOutput: ['Success: 1']


### PR DESCRIPTION
OCI is out of scope for an example that centers on Maven deps for Java builds. The OCI part should be moved to rules_oci.

See https://github.com/bazel-contrib/rules_oci/pull/905

Fixes a Bazel Downstream pipeline breakage.