### PR TITLE
[Downstream] Skip Docker-related Java Maven tests

### DIFF
--- a/.bazelci/misc.yml
+++ b/.bazelci/misc.yml
@@ -8,6 +8,10 @@ tasks:
     - "..."
     test_targets:
     - "..."
+    test_flags:
+    # NOTE: BazelCI no longer supports Docker container spawning, so the
+    # Docker-related tests can no longer be run in CI.
+    - "--test_tag_filters=-requires-docker"
   java-maven-macos:
     name: "Maven Java App"
     platform: macos


### PR DESCRIPTION
Docker in BazelCI is no longer supported.